### PR TITLE
Prevent unexpected behaviour from malformed trailing query string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,14 @@
 //!
 //! * The [`NodeList`] struct, which represents the result of a JSONPath query performed on a
 //!   [`serde_json::Value`].
-//! * The [`JsonPathExt`] trait, which provides an extension to the [`serde_json::Value`] type so that
-//!   queries can be performed using an ergonomic API.
+//! * The [`JsonPathExt`] trait, which extends the [`serde_json::Value`] type with the
+//!   [`json_path`][JsonPathExt::json_path] method for performing JSONPath queries.
 //!
-//! # Examples
+//! # Usage
 //!
 //! ## Query for single nodes
+//!
+//! For queries that are expected to return a single node, use the [`one`][NodeList::one] method:
 //!
 //! ```rust
 //! use serde_json::json;
@@ -29,14 +31,29 @@
 //! # Ok(())
 //! # }
 //! ```
-//! In this scenario, the only additional functionality that JSONPath provides over JSON Pointer,
-//! and thereby the [`serde_json::Value::pointer`] method, is that you can use reverse array indexes.
+//! In this regard, the only additional functionality that JSONPath provides over JSON Pointer,
+//! and thereby the [`serde_json::Value::pointer`] method, is that you can use reverse array indices:
+//!
+//! ```rust
+//! # use serde_json::json;
+//! # use serde_json_path::JsonPathExt;
+//! # fn main() -> Result<(), serde_json_path::Error> {
+//! let value = json!([1, 2, 3, 4, 5]);
+//! let node = value.json_path("$[-1]")?.one().unwrap();
+//! assert_eq!(node, 5);
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! ## Query for multiple nodes
 //!
-//! With JSONPath you can form queries to extract multiple nodes from with a JSON value.
+//! For queries that you expect to return zero or many nodes, use the [`all`][NodeList::all]
+//! method. There are several selectors in JSONPath that allow you to do this.
 //!
-//! #### Use wildcards (`*`)
+//! #### Wildcards (`*`)
+//!
+//! Wildcards select everything under a current node. They work on both arrays, by selecting all
+//! array elements, and on objects, by selecting all object key values:
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -49,7 +66,11 @@
 //! # }
 //! ```
 //!
-//! #### Use the slice selector (`start:end:step`)
+//! #### Slice selectors (`start:end:step`)
+//!
+//! Extract slices from JSON arrays using optional `start`, `end`, and `step` values. Reverse
+//! indices can be used for `start` and `end`, and a negative `step` can be used to traverse
+//! the array in reverse order.
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -62,20 +83,63 @@
 //! # }
 //! ```
 //!
-//! #### Use filter expressions (`?`)
+//! #### Filter expressions (`?`)
+//!
+//! Filter selectors allow you to perform comparisons and check for existence of nodes. You can
+//! combine these checks using the boolean `&&` and `||` operators and group using parentheses.
+//! The current node (`@`) operator allows you to apply the filtering logic based on the current
+//! node being filtered:
 //!
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPathExt;
 //! # fn main() -> Result<(), serde_json_path::Error> {
 //! let value = json!({ "foo": [1, 2, 3, 4, 5] });
-//! let nodes = value.json_path("$.foo[?@ > 2]")?.all();
-//! assert_eq!(nodes, vec![3, 4, 5]);
+//! let nodes = value.json_path("$.foo[?@ > 2 && @ < 5]")?.all();
+//! assert_eq!(nodes, vec![3, 4]);
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! #### Extract deeply nested values
+//! You can form relative paths on the current node, as well as absolute paths on the root (`$`)
+//! node when writing filters:
+//!
+//! ```rust
+//! # use serde_json::json;
+//! # use serde_json_path::JsonPathExt;
+//! # fn main() -> Result<(), serde_json_path::Error> {
+//! let value = json!([
+//!     { "title": "Great Expectations", "price": 10 },
+//!     { "title": "Tale of Two Cities", "price": 8 },
+//!     { "title": "David Copperfield", "price": 17 }
+//! ]);
+//! let nodes = value.json_path("$[?@.price > $[0].price].title")?.all();
+//! assert_eq!(nodes, vec!["David Copperfield"]);
+//! # Ok(())
+//! # }
+//! ```
+//! #### Recursive descent (`..`)
+//!
+//! ```rust
+//! # use serde_json::json;
+//! # use serde_json_path::JsonPathExt;
+//! # fn main() -> Result<(), serde_json_path::Error> {
+//! let value = json!({
+//!     "foo": {
+//!         "bar": {
+//!             "baz": 1
+//!         },
+//!         "baz": 2
+//!     }
+//! });
+//! let nodes = value.json_path("$.foo..baz")?.all();
+//! assert_eq!(nodes, vec![2, 1]);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! As seen there, one of the useful features of JSONPath is its ability to extract deeply nested values.
+//! Here is another example:
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -94,21 +158,10 @@
 //! # }
 //! ```
 //!
-//! #### Use reverse array indexes
+//! You can combine the above selectors to form powerful and useful queries with JSONPath.
 //!
-//! ```rust
-//! # use serde_json::json;
-//! # use serde_json_path::JsonPathExt;
-//! # fn main() -> Result<(), serde_json_path::Error> {
-//! let value = json!([1, 2, 3, 4, 5]);
-//! let node = value.json_path("$[-1]")?.one().unwrap();
-//! assert_eq!(node, 5);
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! And much more! Check out the [integration tests][tests] in the repository for more examples
-//! based on those found in the JSONPath specification.
+//! See the [integration tests][tests] in the repository for more examples based on those found in
+//! the JSONPath specification.
 //!
 //! # Unimplemented Features
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! Please note that the specification has not yet been published as an RFC; therefore, this crate
 //! may evolve as JSONPath becomes standardized. See [Unimplemented Features](#unimplemented-features)
-//! for more details on which parts of the specification are not implemented.
+//! for more details on which parts of the specification are not implemented by this crate.
 //!
 //! This crate provides two key abstractions:
 //!
@@ -16,7 +16,7 @@
 //!
 //! # Examples
 //!
-//! Query single nodes:
+//! ## Query for single nodes
 //!
 //! ```rust
 //! use serde_json::json;
@@ -29,8 +29,14 @@
 //! # Ok(())
 //! # }
 //! ```
+//! In this scenario, the only additional functionality that JSONPath provides over JSON Pointer,
+//! and thereby the [`serde_json::Value::pointer`] method, is that you can use reverse array indexes.
 //!
-//! Use wildcards (`*`):
+//! ## Query for multiple nodes
+//!
+//! With JSONPath you can form queries to extract multiple nodes from with a JSON value.
+//!
+//! #### Use wildcards (`*`)
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -43,7 +49,7 @@
 //! # }
 //! ```
 //!
-//! Use the slice selector (`start:end:step`):
+//! #### Use the slice selector (`start:end:step`)
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -56,7 +62,7 @@
 //! # }
 //! ```
 //!
-//! Use filter expressions (`?`):
+//! #### Use filter expressions (`?`)
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -69,7 +75,7 @@
 //! # }
 //! ```
 //!
-//! Extract deeply nested values:
+//! #### Extract deeply nested values
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -88,7 +94,7 @@
 //! # }
 //! ```
 //!
-//! Use reverse array indexes:
+//! #### Use reverse array indexes
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -119,7 +125,7 @@
 use std::{ops::Deref, slice::Iter};
 
 use nom::error::{convert_error, VerboseError};
-use parser::parse_path;
+use parser::parse_path_main;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -246,7 +252,7 @@ pub trait JsonPathExt {
 
 impl JsonPathExt for Value {
     fn json_path(&self, path_str: &str) -> Result<NodeList, Error> {
-        let (_, path) = parse_path(path_str).map_err(|err| match err {
+        let (_, path) = parse_path_main(path_str).map_err(|err| match err {
             nom::Err::Error(e) | nom::Err::Failure(e) => (path_str, e),
             nom::Err::Incomplete(_) => unreachable!("we do not use streaming parsers"),
         })?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,5 @@
 use nom::character::complete::char;
+use nom::combinator::all_consuming;
 use nom::error::VerboseError;
 use nom::{branch::alt, combinator::map, multi::many0, sequence::preceded, IResult};
 use serde_json::Value;
@@ -62,6 +63,10 @@ pub fn parse_path(input: &str) -> PResult<Query> {
     ))(input)
 }
 
+pub fn parse_path_main(input: &str) -> PResult<Query> {
+    all_consuming(parse_path)(input)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::parser::{
@@ -70,7 +75,7 @@ mod tests {
         PathKind,
     };
 
-    use super::parse_path;
+    use super::{parse_path, parse_path_main};
 
     #[test]
     fn root_path() {
@@ -97,5 +102,10 @@ mod tests {
             let (_, p) = parse_path("@").unwrap();
             assert!(matches!(p.kind, PathKind::Current));
         }
+    }
+
+    #[test]
+    fn no_tail() {
+        assert!(parse_path_main("$.a['b']tail").is_err());
     }
 }


### PR DESCRIPTION
This PR adds the use of nom's `all_consuming` parser to the top level path parser, to ensure that any malformed JSONPath segments at the tail end of the query string are not discarded and ignored, leading to unexpected behaviour.

Some of the docs were also updated.