### PR TITLE
[11] `NodeList` API Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** Derive `PartialEq` on `JsonPath` ([#13])
 - **added:** Add the `NodeList::at_most_one` method ([#13])
 - **added:** Add the `NodeList::exactly_one` method ([#13])
 - **deprecated:** Deprecate the `NodeList::one` method in favor of the new `NodeList::at_most_one` method ([#13])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** Add the `NodeList::at_most_one` method ([#13])
+- **added:** Add the `NodeList::exactly_one` method ([#13])
+- **deprecated:** Deprecate the `NodeList::one` method in favor of the new `NodeList::at_most_one` method ([#13])
+
+[#13]: https://github.com/hiltontj/serde_json_path/pull/13
+
 # 0.5.0 (10 March 2023)
 
 ## The `JsonPath` type
@@ -22,9 +28,8 @@ let nodes = path.query(&value).all();
 assert_eq!(nodes, vec![1, 2, 3]);
 ```
 
-`JsonPath` comes with some trait implementations, namely:
+`JsonPath` implements `serde`'s `Deserialize`, which allows it to be used directly in serialized formats
 
-- `serde`'s `Deserialize`, which allows it to be used directly in serialized formats
 ```rust
 #[derive(Deserialize)]
 struct Config {
@@ -36,7 +41,9 @@ let value = json!({"foo": [1, 2, 3]});
 let nodes = config.path.query(&value).all();
 assert_eq!(nodes, vec![1, 2, 3]);
 ```
-- `FromStr`, for convenience, e.g.,
+
+`JsonPath` also implements `FromStr`, for convenience, e.g.,
+
 ```rust
 let path = "$.foo.*".parse::<JsonPath>()?;
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,17 @@
 //!
 //! ## Query for single nodes
 //!
-//! For queries that are expected to return a single node, use the [`one`][NodeList::one] method:
+//! For queries that are expected to return a single node, use either the
+//! [`exactly_one`][NodeList::exactly_one] or the [`at_most_one`][NodeList::at_most_one] method:
 //!
 //! ```rust
 //! use serde_json::json;
 //! use serde_json_path::JsonPath;
 //!
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let value = json!({ "foo": { "bar": ["baz", 42] } });
 //! let path = JsonPath::parse("$.foo.bar[0]")?;
-//! let node = path.query(&value).at_most_one().unwrap();
+//! let node = path.query(&value).exactly_one()?;
 //! assert_eq!(node, "baz");
 //! # Ok(())
 //! # }
@@ -42,7 +43,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let value = json!([1, 2, 3, 4, 5]);
 //! let path = JsonPath::parse("$[-1]")?;
 //! let node = path.query(&value).at_most_one().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! # fn main() -> Result<(), serde_json_path::Error> {
 //! let value = json!({ "foo": { "bar": ["baz", 42] } });
 //! let path = JsonPath::parse("$.foo.bar[0]")?;
-//! let node = path.query(&value).one().unwrap();
+//! let node = path.query(&value).at_most_one().unwrap();
 //! assert_eq!(node, "baz");
 //! # Ok(())
 //! # }
@@ -45,7 +45,7 @@
 //! # fn main() -> Result<(), serde_json_path::Error> {
 //! let value = json!([1, 2, 3, 4, 5]);
 //! let path = JsonPath::parse("$[-1]")?;
-//! let node = path.query(&value).one().unwrap();
+//! let node = path.query(&value).at_most_one().unwrap();
 //! assert_eq!(node, 5);
 //! # Ok(())
 //! # }
@@ -310,9 +310,9 @@ pub struct NodeList<'a> {
 }
 
 impl<'a> NodeList<'a> {
-    /// Extract exactly one node from a [`NodeList`]
+    /// Extract _at most_ one node from a [`NodeList`]
     ///
-    /// This is intended for queries that are expected to yield a single node.
+    /// This is intended for queries that are expected to optionally yield a single node.
     ///
     /// # Usage
     /// ```rust
@@ -322,22 +322,56 @@ impl<'a> NodeList<'a> {
     /// let value = json!({"foo": ["bar", "baz"]});
     /// # {
     /// let path = JsonPath::parse("$.foo[0]")?;
-    /// let node = path.query(&value).one();
+    /// let node = path.query(&value).at_most_one();
     /// assert_eq!(node, Some(&json!("bar")));
     /// # }
     /// # {
     /// let path = JsonPath::parse("$.foo.*")?;
-    /// let node = path.query(&value).one();
+    /// let node = path.query(&value).at_most_one();
     /// assert!(node.is_none());
     /// # }
     /// # Ok(())
     /// # }
     /// ```
-    pub fn one(self) -> Option<&'a Value> {
+    pub fn at_most_one(self) -> Option<&'a Value> {
         if self.nodes.is_empty() || self.nodes.len() > 1 {
             None
         } else {
             self.nodes.get(0).copied()
+        }
+    }
+
+    /// Extract _exactly_ one node from a [`NodeList`]
+    ///
+    /// This is intended for queries that are expected to yield exactly one node.
+    ///
+    /// # Usage
+    /// ```rust
+    /// # use serde_json::json;
+    /// # use serde_json_path::JsonPath;
+    /// # use serde_json_path::ExactlyOneError;
+    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// let value = json!({"foo": ["bar", "baz"]});
+    /// # {
+    /// let path = JsonPath::parse("$.foo[0]")?;
+    /// let node = path.query(&value).exactly_one().unwrap();
+    /// assert_eq!(node, "bar");
+    /// # }
+    /// # {
+    /// let path = JsonPath::parse("$.foo.*")?;
+    /// let error = path.query(&value).exactly_one().unwrap_err();
+    /// assert!(matches!(error, ExactlyOneError::MoreThanOne(2)));
+    /// # }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn exactly_one(self) -> Result<&'a Value, ExactlyOneError> {
+        if self.nodes.is_empty() {
+            Err(ExactlyOneError::Empty)
+        } else if self.nodes.len() > 1 {
+            Err(ExactlyOneError::MoreThanOne(self.nodes.len()))
+        } else {
+            Ok(self.nodes.get(0).unwrap())
         }
     }
 
@@ -377,6 +411,46 @@ impl<'a> NodeList<'a> {
     pub fn iter(&self) -> Iter<'_, &Value> {
         self.nodes.iter()
     }
+
+    /// Extract _at most_ one node from a [`NodeList`]
+    ///
+    /// This is intended for queries that are expected to optionally yield a single node.
+    ///
+    /// # Usage
+    /// ```rust
+    /// # use serde_json::json;
+    /// # use serde_json_path::JsonPath;
+    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// let value = json!({"foo": ["bar", "baz"]});
+    /// # {
+    /// let path = JsonPath::parse("$.foo[0]")?;
+    /// let node = path.query(&value).one();
+    /// assert_eq!(node, Some(&json!("bar")));
+    /// # }
+    /// # {
+    /// let path = JsonPath::parse("$.foo.*")?;
+    /// let node = path.query(&value).one();
+    /// assert!(node.is_none());
+    /// # }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[deprecated(since = "0.5.1", note = "please use `at_most_one` instead")]
+    pub fn one(self) -> Option<&'a Value> {
+        if self.nodes.is_empty() || self.nodes.len() > 1 {
+            None
+        } else {
+            self.nodes.get(0).copied()
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExactlyOneError {
+    #[error("nodelist expected to contain one entry, but is empty")]
+    Empty,
+    #[error("nodelist expected to contain one entry, but instead contains {0} entries")]
+    MoreThanOne(usize),
 }
 
 impl<'a> From<Vec<&'a Value>> for NodeList<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ mod parser;
 /// ```
 ///
 /// [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-10.html
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct JsonPath(Query);
 
 impl JsonPath {

--- a/tests/spec_examples.rs
+++ b/tests/spec_examples.rs
@@ -95,7 +95,7 @@ fn spec_example_4() {
 fn spec_example_5() {
     let value = spec_example_json();
     let path = JsonPath::parse("$..book[2]").unwrap();
-    let node = path.query(&value).one();
+    let node = path.query(&value).at_most_one();
     assert!(node.is_some());
     assert_eq!(node, value.pointer("/store/book/2"));
 }
@@ -104,7 +104,7 @@ fn spec_example_5() {
 fn spec_example_6() {
     let value = spec_example_json();
     let path = JsonPath::parse("$..book[-1]").unwrap();
-    let node = path.query(&value).one();
+    let node = path.query(&value).at_most_one();
     assert!(node.is_some());
     assert_eq!(node, value.pointer("/store/book/3"));
 }

--- a/tests/spec_examples.rs
+++ b/tests/spec_examples.rs
@@ -95,7 +95,7 @@ fn spec_example_4() {
 fn spec_example_5() {
     let value = spec_example_json();
     let path = JsonPath::parse("$..book[2]").unwrap();
-    let node = path.query(&value).at_most_one();
+    let node = path.query(&value).at_most_one().unwrap();
     assert!(node.is_some());
     assert_eq!(node, value.pointer("/store/book/2"));
 }
@@ -104,7 +104,7 @@ fn spec_example_5() {
 fn spec_example_6() {
     let value = spec_example_json();
     let path = JsonPath::parse("$..book[-1]").unwrap();
-    let node = path.query(&value).at_most_one();
+    let node = path.query(&value).at_most_one().unwrap();
     assert!(node.is_some());
     assert_eq!(node, value.pointer("/store/book/3"));
 }


### PR DESCRIPTION
This PR extends the `NodeList` type's API to include two new methods: `NodeList::exactly_one` and `NodeList::at_most_one`.

Consider the following `Value`:

```rust
let value = json!({"foo": ["bar", "baz"]});
```

The `at_most_one` method is meant to replace the original `one` method. It works similarly, however, is fallible in the case where more than one node is produced by the query:

```rust
let path = JsonPath::parse("$.foo[10]")?;
let node = path.query(&value).at_most_one().unwrap();
assert_eq!(node, None);
```
```rust
let path = JsonPath::parse("$.foo[0]")?;
let node = path.query(&value).at_most_one().unwrap();
assert_eq!(node, Some(&json!("bar")));
```
```rust
let path = JsonPath::parse("$.foo.*")?;
let error = path.query(&value).at_most_one().unwrap_err();
assert!(matches!(error, AtMostOneError(2)));
```

The `exactly_one` method is similar, but for cases where a JSON Path is expected to return exactly a single node, and you want to raise an error when it does not.

```rust
let value = json!({"foo": ["bar", "baz"]});
let path = JsonPath::parse("$.foo[0]")?;
let node = path.query(&value).exactly_one().unwrap();
assert_eq!(node, "bar");
```
```rust
let path = JsonPath::parse("$.foo[-10]")?;
let error = path.query(&value).exactly_one().unwrap_err();
assert!(matches!(error, ExactlyOneError::Empty));
```
```rust
let path = JsonPath::parse("$.foo.*")?;
let error = path.query(&value).exactly_one().unwrap_err();
assert!(matches!(error, ExactlyOneError::MoreThanOne(2)));
```

The `one` method was left in the API, with a deprecation notice, so that this would not be a breaking change.