### PR TITLE
Fix new clippy lints for 1.68.0

### DIFF
--- a/src/parser/primitive/string.rs
+++ b/src/parser/primitive/string.rs
@@ -21,7 +21,7 @@ enum Quotes {
 }
 
 fn is_digit(chr: &char) -> bool {
-    ('0'..='9').contains(chr)
+    chr.is_ascii_digit()
 }
 
 fn is_hex_digit(chr: char) -> bool {


### PR DESCRIPTION
This PR fixes the new clippy lints introduced in 1.68.0, and that were caught by the new CI action.