### PR TITLE
Add tests to ensure Send and Sync on public API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,3 +19,20 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Error;
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Error>();
+    }
+
+    #[test]
+    fn test_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Error>();
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -202,7 +202,7 @@ impl<'a> IntoIterator for NodeList<'a> {
 mod tests {
     use serde_json::json;
 
-    use crate::JsonPath;
+    use crate::{JsonPath, NodeList};
 
     #[test]
     fn api_tests() {
@@ -211,5 +211,17 @@ mod tests {
         assert_eq!(q.first().unwrap(), 1);
         assert_eq!(q.last().unwrap(), 5);
         assert_eq!(q.get(1).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<NodeList>();
+    }
+
+    #[test]
+    fn test_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<NodeList>();
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -110,3 +110,20 @@ impl<'de> Deserialize<'de> for JsonPath {
         deserializer.deserialize_str(JsonPathVisitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::JsonPath;
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<JsonPath>();
+    }
+
+    #[test]
+    fn test_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<JsonPath>();
+    }
+}


### PR DESCRIPTION
This PR adds tests to ensure that the `JsonPath` and `NodeList` remain `Send` and `Sync`.