### PR TITLE
[23] Implement `Clone` for `JsonPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** Make `NodeList::at_most_one` and `NodeList::exactly_one` take `&self` instead of `self` ([#16])
 - **docs:** Update crate-level docs to better reflect recent changes ([#21])
 - **docs:** Corrected a broken link in crate-level docs ([#21])
+- **added:** derive `Clone` for `JsonPath` and its descendants ([#24])
 
 [#16]: https://github.com/hiltontj/serde_json_path/pull/16
 [#21]: https://github.com/hiltontj/serde_json_path/pull/21
+[#24]: https://github.com/hiltontj/serde_json_path/pull/24
 
 # 0.5.1 (11 March 2023)
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,13 +17,13 @@ pub trait QueryValue {
 }
 
 /// Represents a JSONPath expression
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Query {
     kind: PathKind,
     pub segments: Vec<PathSegment>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum PathKind {
     Root,
     Current,

--- a/src/parser/segment.rs
+++ b/src/parser/segment.rs
@@ -16,13 +16,13 @@ use serde_json::Value;
 use super::selector::{parse_selector, parse_wildcard_selector, Selector};
 use super::{PResult, QueryValue};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct PathSegment {
     pub kind: PathSegmentKind,
     pub segment: Segment,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum PathSegmentKind {
     Child,
     Descendant,
@@ -52,7 +52,7 @@ fn descend<'b>(segment: &PathSegment, current: &'b Value, root: &'b Value) -> Ve
     query
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Segment {
     LongHand(Vec<Selector>),
     DotName(String),

--- a/src/parser/selector/filter.rs
+++ b/src/parser/selector/filter.rs
@@ -17,7 +17,7 @@ trait TestFilter {
     fn test_filter<'b>(&self, current: &'b Value, root: &'b Value) -> bool;
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Filter(BooleanExpr);
 
 impl QueryValue for Filter {
@@ -47,7 +47,7 @@ pub fn parse_filter(input: &str) -> PResult<Filter> {
 /// A Boolean Expression
 ///
 /// In the JSONPath spec, this is the same as a logical or expression.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 struct BooleanExpr(Vec<LogicalAndExpr>);
 
 impl TestFilter for BooleanExpr {
@@ -56,7 +56,7 @@ impl TestFilter for BooleanExpr {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 struct LogicalAndExpr(Vec<BasicExpr>);
 
 impl TestFilter for LogicalAndExpr {
@@ -79,7 +79,7 @@ fn parse_boolean_expr(input: &str) -> PResult<BooleanExpr> {
     )(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 enum BasicExpr {
     Paren(BooleanExpr),
     NotParen(BooleanExpr),
@@ -115,7 +115,7 @@ impl TestFilter for BasicExpr {
 /// ### Implementation Note
 ///
 /// This does not support the function expression notation outlined in the JSONPath spec.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 struct ExistExpr(Query);
 
 impl TestFilter for ExistExpr {
@@ -168,7 +168,7 @@ fn parse_basic_expr(input: &str) -> PResult<BasicExpr> {
     ))(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 struct ComparisonExpr {
     pub left: Comparable,
     pub op: ComparisonOperator,
@@ -260,7 +260,7 @@ fn parse_comparison_operator(input: &str) -> PResult<ComparisonOperator> {
     ))(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 enum Comparable {
     Primitive {
         kind: ComparablePrimitiveKind,
@@ -270,7 +270,7 @@ enum Comparable {
     // FunctionExpr, // TODO - function expressions are hard
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum ComparablePrimitiveKind {
     Number,
     String,
@@ -370,7 +370,7 @@ fn parse_string_comparable(input: &str) -> PResult<Comparable> {
     })(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 enum SingularPathSegment {
     Name(Name),
     Index(Index),
@@ -400,7 +400,7 @@ fn parse_singular_path_segments(input: &str) -> PResult<Vec<SingularPathSegment>
     ))(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 struct SingularPath {
     kind: SingularPathKind,
     pub segments: Vec<SingularPathSegment>,
@@ -438,7 +438,7 @@ impl SingularPath {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum SingularPathKind {
     Absolute,
     Relative,

--- a/src/parser/selector/mod.rs
+++ b/src/parser/selector/mod.rs
@@ -15,7 +15,7 @@ use super::{PResult, QueryValue};
 pub mod filter;
 pub mod slice;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Selector {
     Name(Name),
     Wildcard,
@@ -52,7 +52,7 @@ pub fn parse_wildcard_selector(input: &str) -> PResult<Selector> {
     map(char('*'), |_| Selector::Wildcard)(input)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Name(pub String);
 
 impl Name {

--- a/src/parser/selector/slice.rs
+++ b/src/parser/selector/slice.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::parser::{primitive::int::parse_int, PResult, QueryValue};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Clone, Copy)]
 pub struct Slice {
     start: Option<isize>,
     end: Option<isize>,

--- a/src/path.rs
+++ b/src/path.rs
@@ -37,7 +37,7 @@ use crate::{
 /// ```
 ///
 /// [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-10.html
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct JsonPath(Query);
 
 impl JsonPath {


### PR DESCRIPTION
The Clone trait was implemented for the `JsonPath` type, by deriving it on all of its nested types.

This is related to #23 .