### PR TITLE
[#23] Implement `Default` for `JsonPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs:** Update crate-level docs to better reflect recent changes ([#21])
 - **docs:** Corrected a broken link in crate-level docs ([#21])
 - **added:** derive `Clone` for `JsonPath` and its descendants ([#24])
+- **added:** derive `Default` for `JsonPath` ([#25])
 
 [#16]: https://github.com/hiltontj/serde_json_path/pull/16
 [#21]: https://github.com/hiltontj/serde_json_path/pull/21
 [#24]: https://github.com/hiltontj/serde_json_path/pull/24
+[#25]: https://github.com/hiltontj/serde_json_path/pull/25
 
 # 0.5.1 (11 March 2023)
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,14 +17,15 @@ pub trait QueryValue {
 }
 
 /// Represents a JSONPath expression
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct Query {
     kind: PathKind,
     pub segments: Vec<PathSegment>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub enum PathKind {
+    #[default]
     Root,
     Current,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -37,7 +37,7 @@ use crate::{
 /// ```
 ///
 /// [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-10.html
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct JsonPath(Query);
 
 impl JsonPath {


### PR DESCRIPTION
This PR implements `Default` for the `JsonPath` type. It defaults to a root JSONPath query, i.e., `$`.

This is addressing, in part, #23 