### PR TITLE
[#23] Implement `Display` and `Serialize` for `JsonPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs:** Corrected a broken link in crate-level docs ([#21])
 - **added:** derive `Clone` for `JsonPath` and its descendants ([#24])
 - **added:** derive `Default` for `JsonPath` ([#25])
+- **added:** implement `Display`  and `Serialize` for `JsonPath` ([#26])
 
 [#16]: https://github.com/hiltontj/serde_json_path/pull/16
 [#21]: https://github.com/hiltontj/serde_json_path/pull/21
 [#24]: https://github.com/hiltontj/serde_json_path/pull/24
 [#25]: https://github.com/hiltontj/serde_json_path/pull/25
+[#26]: https://github.com/hiltontj/serde_json_path/pull/26
 
 # 0.5.1 (11 March 2023)
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,6 +23,19 @@ pub struct Query {
     pub segments: Vec<PathSegment>,
 }
 
+impl std::fmt::Display for Query {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            PathKind::Root => write!(f, "$")?,
+            PathKind::Current => write!(f, "@")?,
+        }
+        for s in &self.segments {
+            write!(f, "{s}")?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Default)]
 pub enum PathKind {
     #[default]

--- a/src/parser/segment.rs
+++ b/src/parser/segment.rs
@@ -22,6 +22,15 @@ pub struct PathSegment {
     pub segment: Segment,
 }
 
+impl std::fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if matches!(self.kind, PathSegmentKind::Descendant) {
+            write!(f, "..")?;
+        }
+        write!(f, "{segment}", segment = self.segment)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum PathSegmentKind {
     Child,
@@ -74,6 +83,27 @@ impl Segment {
             Segment::DotName(s) => Some(s.as_str()),
             _ => None,
         }
+    }
+}
+
+impl std::fmt::Display for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Segment::LongHand(selectors) => {
+                write!(f, "[")?;
+                for (i, s) in selectors.iter().enumerate() {
+                    write!(
+                        f,
+                        "{s}{comma}",
+                        comma = if i == selectors.len() - 1 { "" } else { "," }
+                    )?;
+                }
+                write!(f, "]")?;
+            }
+            Segment::DotName(name) => write!(f, ".{name}")?,
+            Segment::Wildcard => write!(f, ".*")?,
+        }
+        Ok(())
     }
 }
 

--- a/src/parser/selector/mod.rs
+++ b/src/parser/selector/mod.rs
@@ -24,6 +24,18 @@ pub enum Selector {
     Filter(Filter),
 }
 
+impl std::fmt::Display for Selector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Selector::Name(name) => write!(f, "{name}"),
+            Selector::Wildcard => write!(f, "*"),
+            Selector::Index(index) => write!(f, "{index}"),
+            Selector::ArraySlice(slice) => write!(f, "{slice}"),
+            Selector::Filter(filter) => write!(f, "?{filter}"),
+        }
+    }
+}
+
 impl QueryValue for Selector {
     fn query_value<'b>(&self, current: &'b Value, root: &'b Value) -> Vec<&'b Value> {
         let mut query = Vec::new();
@@ -61,6 +73,12 @@ impl Name {
     }
 }
 
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "'{name}'", name = self.0)
+    }
+}
+
 impl QueryValue for Name {
     fn query_value<'b>(&self, current: &'b Value, _root: &'b Value) -> Vec<&'b Value> {
         if let Some(obj) = current.as_object() {
@@ -87,6 +105,12 @@ fn parse_name_selector(input: &str) -> PResult<Selector> {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Index(pub isize);
+
+impl std::fmt::Display for Index {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{index}", index = self.0)
+    }
+}
 
 impl QueryValue for Index {
     fn query_value<'b>(&self, current: &'b Value, _root: &'b Value) -> Vec<&'b Value> {

--- a/src/parser/selector/slice.rs
+++ b/src/parser/selector/slice.rs
@@ -15,6 +15,23 @@ pub struct Slice {
     step: Option<isize>,
 }
 
+impl std::fmt::Display for Slice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(start) = self.start {
+            write!(f, "{start}")?;
+        }
+        write!(f, ":")?;
+        if let Some(end) = self.end {
+            write!(f, "{end}")?;
+        }
+        write!(f, ":")?;
+        if let Some(step) = self.step {
+            write!(f, "{step}")?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 impl Slice {
     pub fn new() -> Self {

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use serde::{de::Visitor, Deserialize};
+use serde::{de::Visitor, Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
@@ -85,6 +85,21 @@ impl FromStr for JsonPath {
     }
 }
 
+impl std::fmt::Display for JsonPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{path}", path = self.0)
+    }
+}
+
+impl Serialize for JsonPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
 impl<'de> Deserialize<'de> for JsonPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -113,6 +128,8 @@ impl<'de> Deserialize<'de> for JsonPath {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::{from_value, json, to_value};
+
     use crate::JsonPath;
 
     #[test]
@@ -125,5 +142,15 @@ mod tests {
     fn test_sync() {
         fn assert_sync<T: Sync>() {}
         assert_sync::<JsonPath>();
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let j1 = json!("$.foo['bar'][1:10][?@.baz > 10 && @.foo.bar < 20]");
+        let p1 = from_value::<JsonPath>(j1).expect("deserializes");
+        let p2 = to_value(&p1)
+            .and_then(from_value::<JsonPath>)
+            .expect("round trip");
+        assert_eq!(p1, p2);
     }
 }


### PR DESCRIPTION
This implements the Display and Serialize traits for the JsonPath type. Although there may be a more efficient way to serialize it than using collect_str, my assumption for now is that JSON Path query strings are not too long and this will not be too costly to rely on the Display impl to allocate a string before writing out to the serializer.

Related to #23 