### PR TITLE
Rename `Error` to `ParseError`

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -93,9 +93,11 @@ isolate cases where specific errors can be propagated up, and give better error 
 
 - **added:** updated to latest version of CTS to ensure compliance [#33]
 - **added:** implement `Eq` for `JsonPath` [#34]
+- **breaking:**: Changed the name of `Error` type to `ParseError` [#36]
 
 [#33]: https://github.com/hiltontj/serde_json_path/pull/33
 [#34]: https://github.com/hiltontj/serde_json_path/pull/34
+[#36]: https://github.com/hiltontj/serde_json_path/pull/36
 
 # 0.5.3 (14 March 2023)
 

--- a/serde_json_path/src/error.rs
+++ b/serde_json_path/src/error.rs
@@ -1,15 +1,15 @@
 use std::ops::Deref;
 
-use crate::parser::ParserError;
+use crate::parser::Error;
 
 /// Error type for the `serde_json_path` crate
 #[derive(Debug, thiserror::Error)]
 #[error("{err}")]
-pub struct Error {
+pub struct ParseError {
     err: Box<ErrorImpl>,
 }
 
-impl Error {
+impl ParseError {
     /// Get the 1-indexed error position
     pub fn position(&self) -> usize {
         self.err.position
@@ -28,11 +28,11 @@ struct ErrorImpl {
     message: Box<str>,
 }
 
-impl<I> From<(I, ParserError<I>)> for Error
+impl<I> From<(I, Error<I>)> for ParseError
 where
     I: Deref<Target = str> + std::fmt::Debug,
 {
-    fn from((input, pe): (I, ParserError<I>)) -> Self {
+    fn from((input, pe): (I, Error<I>)) -> Self {
         #[cfg(feature = "trace")]
         tracing::trace!(input = %input.to_string(), parser_error = ?pe);
         let position = pe.calculate_position(input);
@@ -45,19 +45,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::Error;
+    use crate::ParseError;
     #[cfg(feature = "trace")]
     use test_log::test;
 
     #[test]
     fn test_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<Error>();
+        assert_send::<ParseError>();
     }
 
     #[test]
     fn test_sync() {
         fn assert_sync<T: Sync>() {}
-        assert_sync::<Error>();
+        assert_sync::<ParseError>();
     }
 }

--- a/serde_json_path/src/error.rs
+++ b/serde_json_path/src/error.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::parser::Error;
 
-/// Error type for the `serde_json_path` crate
+/// Error type for JSONPath query string parsing errors
 #[derive(Debug, thiserror::Error)]
 #[error("{err}")]
 pub struct ParseError {

--- a/serde_json_path/src/ext.rs
+++ b/serde_json_path/src/ext.rs
@@ -9,7 +9,7 @@ use crate::{JsonPath, NodeList};
 /// use serde_json::json;
 /// use serde_json_path::{JsonPath, JsonPathExt};
 ///
-/// # fn main() -> Result<(), serde_json_path::Error> {
+/// # fn main() -> Result<(), serde_json_path::ParseError> {
 /// let value = json!({"foo": ["bar", "baz"]});
 /// let query = JsonPath::parse("$.foo[*]")?;
 /// let nodes = value.json_path(&query).all();

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -29,7 +29,7 @@
 //! ```rust
 //! use serde_json_path::JsonPath;
 //!
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let path = JsonPath::parse("$.foo.bar")?;
 //! # Ok(())
 //! # }
@@ -89,7 +89,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!({ "foo": { "bar": ["baz", "bop"] } });
 //! let path = JsonPath::parse("$.foo.bar[*]")?;
 //! let nodes = path.query(&value).all();
@@ -107,7 +107,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!({ "foo": ["bar", "baz", "bop"] });
 //! let path = JsonPath::parse("$['foo'][1:]")?;
 //! let nodes = path.query(&value).all();
@@ -126,7 +126,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!({ "foo": [1, 2, 3, 4, 5] });
 //! let path = JsonPath::parse("$.foo[?@ > 2 && @ < 5]")?;
 //! let nodes = path.query(&value).all();
@@ -141,7 +141,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!([
 //!     { "title": "Great Expectations", "price": 10 },
 //!     { "title": "Tale of Two Cities", "price": 8 },
@@ -159,7 +159,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!([
 //!     "a short string",
 //!     "a longer string",
@@ -177,7 +177,7 @@
 //! ```rust
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
-//! # fn main() -> Result<(), serde_json_path::Error> {
+//! # fn main() -> Result<(), serde_json_path::ParseError> {
 //! let value = json!({
 //!     "foo": {
 //!         "bar": {
@@ -241,7 +241,7 @@ mod parser;
 mod path;
 
 #[doc(inline)]
-pub use error::Error;
+pub use error::ParseError;
 #[doc(inline)]
 pub use ext::JsonPathExt;
 #[doc(inline)]

--- a/serde_json_path/src/parser/mod.rs
+++ b/serde_json_path/src/parser/mod.rs
@@ -16,14 +16,14 @@ pub(crate) mod segment;
 pub(crate) mod selector;
 pub(crate) mod utils;
 
-type PResult<'a, O> = IResult<&'a str, O, ParserError<&'a str>>;
+type PResult<'a, O> = IResult<&'a str, O, Error<&'a str>>;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct ParserError<I> {
+pub(crate) struct Error<I> {
     pub(crate) errors: Vec<ParserErrorInner<I>>,
 }
 
-impl<I> ParserError<I>
+impl<I> Error<I>
 where
     I: Deref<Target = str>,
 {
@@ -35,7 +35,7 @@ where
     }
 }
 
-impl<I> std::fmt::Display for ParserError<I> {
+impl<I> std::fmt::Display for Error<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(e) = self.errors.first() {
             if let Some(ctx) = e.context {
@@ -48,7 +48,7 @@ impl<I> std::fmt::Display for ParserError<I> {
     }
 }
 
-impl<I: std::fmt::Debug + std::fmt::Display> std::error::Error for ParserError<I> {}
+impl<I: std::fmt::Debug + std::fmt::Display> std::error::Error for Error<I> {}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct ParserErrorInner<I> {
@@ -65,7 +65,7 @@ pub(crate) enum ParserErrorKind {
     Nom(ErrorKind),
 }
 
-impl<I> ParseError<I> for ParserError<I> {
+impl<I> ParseError<I> for Error<I> {
     fn from_error_kind(input: I, kind: ErrorKind) -> Self {
         Self {
             errors: vec![ParserErrorInner {
@@ -86,7 +86,7 @@ impl<I> ParseError<I> for ParserError<I> {
     }
 }
 
-impl<I> ContextError<I> for ParserError<I> {
+impl<I> ContextError<I> for Error<I> {
     fn add_context(_input: I, ctx: &'static str, mut other: Self) -> Self {
         if let Some(e) = other.errors.first_mut() {
             e.context = Some(ctx);
@@ -95,7 +95,7 @@ impl<I> ContextError<I> for ParserError<I> {
     }
 }
 
-impl<I, E> FromExternalError<I, E> for ParserError<I>
+impl<I, E> FromExternalError<I, E> for Error<I>
 where
     E: std::error::Error + Display,
 {
@@ -114,7 +114,7 @@ pub(crate) trait FromInternalError<I, E> {
     fn from_internal_error(input: I, e: E) -> Self;
 }
 
-impl<I, E> FromInternalError<I, E> for ParserError<I>
+impl<I, E> FromInternalError<I, E> for Error<I>
 where
     E: std::error::Error + Display,
 {

--- a/serde_json_path/src/path.rs
+++ b/serde_json_path/src/path.rs
@@ -7,7 +7,7 @@ use serde_json_path_core::{
     spec::query::{Query, Queryable},
 };
 
-use crate::{parser::parse_query_main, Error};
+use crate::{parser::parse_query_main, ParseError};
 
 /// A parsed JSON Path query string
 ///
@@ -50,7 +50,7 @@ impl JsonPath {
     /// let path = JsonPath::parse("$.foo[1:10:2].baz").expect("valid JSON Path");
     /// # }
     /// ```
-    pub fn parse(path_str: &str) -> Result<Self, Error> {
+    pub fn parse(path_str: &str) -> Result<Self, ParseError> {
         let (_, path) = parse_query_main(path_str).map_err(|err| match err {
             nom::Err::Error(e) | nom::Err::Failure(e) => (path_str, e),
             nom::Err::Incomplete(_) => unreachable!("we do not use streaming parsers"),
@@ -64,7 +64,7 @@ impl JsonPath {
     /// ```rust
     /// # use serde_json::json;
     /// # use serde_json_path::JsonPath;
-    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
     /// let path = JsonPath::parse("$.foo[::2]")?;
     /// let value = json!({"foo": [1, 2, 3, 4]});
     /// let nodes = path.query(&value);
@@ -78,7 +78,7 @@ impl JsonPath {
 }
 
 impl FromStr for JsonPath {
-    type Err = Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         JsonPath::parse(s)

--- a/serde_json_path_core/src/node.rs
+++ b/serde_json_path_core/src/node.rs
@@ -21,7 +21,7 @@ impl<'a> NodeList<'a> {
     /// # use serde_json::json;
     /// # use serde_json_path::JsonPath;
     /// # use serde_json_path::AtMostOneError;
-    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
     /// let value = json!({"foo": ["bar", "baz"]});
     /// # {
     /// let path = JsonPath::parse("$.foo[0]")?;
@@ -55,7 +55,7 @@ impl<'a> NodeList<'a> {
     /// # use serde_json::json;
     /// # use serde_json_path::JsonPath;
     /// # use serde_json_path::ExactlyOneError;
-    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
     /// let value = json!({"foo": ["bar", "baz"]});
     /// # {
     /// let path = JsonPath::parse("$.foo[0]")?;
@@ -88,7 +88,7 @@ impl<'a> NodeList<'a> {
     /// ```rust
     /// # use serde_json::json;
     /// # use serde_json_path::JsonPath;
-    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
     /// let value = json!({"foo": ["bar", "baz"]});
     /// let path = JsonPath::parse("$.foo.*")?;
     /// let nodes = path.query(&value).all();
@@ -141,7 +141,7 @@ impl<'a> NodeList<'a> {
     /// ```rust
     /// # use serde_json::json;
     /// # use serde_json_path::JsonPath;
-    /// # fn main() -> Result<(), serde_json_path::Error> {
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
     /// let value = json!({"foo": ["bar", "baz"]});
     /// # {
     /// let path = JsonPath::parse("$.foo[0]")?;


### PR DESCRIPTION
The Error type was renamed to ParseError to reflect the fact that it is only used for parsing errors.

This is not related to any issues.