### PR TITLE
Fix `Cargo.toml` files for publishing

### DIFF
--- a/serde_json_path/Cargo.toml
+++ b/serde_json_path/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "serde_json_path"
-# Remember to update the versions in other crates when changing this:
 version = "0.6.0"
 edition = "2021"
 license = "MIT"

--- a/serde_json_path_core/Cargo.toml
+++ b/serde_json_path_core/Cargo.toml
@@ -25,4 +25,5 @@ thiserror = "1.0"
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
-serde_json_path = { path = "../serde_json_path", version = "0.6.0" }
+serde_json_path = { path = "../serde_json_path" }
+

--- a/serde_json_path_macros/Cargo.toml
+++ b/serde_json_path_macros/Cargo.toml
@@ -19,4 +19,4 @@ once_cell = "1"
 
 [dev-dependencies]
 serde_json = "1"
-serde_json_path = { path = "../serde_json_path", version = "0.6.0" }
+


### PR DESCRIPTION
* The version was removed from the `serde_json_path_core` crate's dev-dependency of `serde_json_path` to allow for publishing to crates.io
* `serde_json_path` was removed as a dev-dependency from `serde_json_path_macros` as it was not used