### PR TITLE
Remove `env_logger` from `serde_json_path`

### DIFF
--- a/serde_json_path/Cargo.toml
+++ b/serde_json_path/Cargo.toml
@@ -28,6 +28,5 @@ thiserror = "1.0"
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
-env_logger = "*"
 test-log = { version = "0.2.11", default-features = false, features=["trace"] }
 tracing-subscriber = { version = "0.3", default-features = false, features=["env-filter", "fmt"] }


### PR DESCRIPTION
The `env_logger` dev-dependency was not being used by `serde_json_path` so it was removed.