### PR TITLE
Update JSONPath Specification Links

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+* **changed**: Updated links to JSONPath specification to latest version (base 14) [#43]
+
+[#43]: https://github.com/hiltontj/serde_json_path/pull/43 
+
 # 0.6.0 (2 April 2023)
 
 ## Function Extensions ([#32])

--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Function Extensions ([#32])
 
-This release introduces the implementation of [Function Extensions][jpspec_base12_func_ext] in `serde_json_path`.
+This release introduces the implementation of [Function Extensions][jpspec_func_ext] in `serde_json_path`.
 
 This release ships with support for the standard built-in functions that are part of the base JSONPath specification:
 
@@ -104,7 +104,7 @@ This split was done to accommodate the new `#[function]` attribute macro, which 
 `serde_json_path_macros`/`macros_internal` crates, and discussed below.
 
 [#32]: https://github.com/hiltontj/serde_json_path/pull/32
-[jpspec_base12_func_ext]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-12.html#name-function-extensions
+[jpspec_func_ext]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html#name-function-extensions
 
 ## Other Changes
 

--- a/serde_json_path/README.md
+++ b/serde_json_path/README.md
@@ -26,5 +26,5 @@ additional terms or conditions.
 [jsonpath]: https://datatracker.ietf.org/wg/jsonpath/about/
 [serde_json_value]: https://docs.rs/serde_json/latest/serde_json/enum.Value.html
 [license]: https://github.com/hiltontj/serde_json_path/blob/main/LICENSE-MIT
-[jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-12.html
+[jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html
 

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -193,8 +193,8 @@
 //! # }
 //! ```
 //!
-//! [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-12.html
-//! [jp_selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-12.html#name-selectors-2
+//! [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html
+//! [jp_selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html#name-selectors-2
 
 #![warn(
     clippy::all,


### PR DESCRIPTION
This closes #40 by updating any links to the JSONPath specification document to the latest version (base 14).