### PR TITLE
[#42] Update CTS and make necessary fixes

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 * **changed**: Updated links to JSONPath specification to latest version (base 14) [#43]
+* **fixed**: Support newline characters in query strings where previously they were not being supported [#44]
 
-[#43]: https://github.com/hiltontj/serde_json_path/pull/43 
+[#43]: https://github.com/hiltontj/serde_json_path/pull/43
+[#44]: https://github.com/hiltontj/serde_json_path/pull/44
 
 # 0.6.0 (2 April 2023)
 

--- a/serde_json_path/src/parser/segment.rs
+++ b/serde_json_path/src/parser/segment.rs
@@ -5,7 +5,7 @@ use nom::sequence::terminated;
 use nom::{
     branch::alt,
     bytes::complete::take_while1,
-    character::complete::{alpha1, digit1, space0},
+    character::complete::{alpha1, digit1, multispace0},
     combinator::{map, recognize},
     multi::{fold_many0, separated_list1},
     sequence::{delimited, pair, preceded},
@@ -63,7 +63,10 @@ fn parse_dot_member_name_shorthand(input: &str) -> PResult<Segment> {
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_multi_selector(input: &str) -> PResult<Vec<Selector>> {
-    separated_list1(delimited(space0, char(','), space0), parse_selector)(input)
+    separated_list1(
+        delimited(multispace0, char(','), multispace0),
+        parse_selector,
+    )(input)
 }
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
@@ -71,11 +74,11 @@ fn parse_child_long_hand(input: &str) -> PResult<Segment> {
     context(
         "long-hand segment",
         preceded(
-            pair(char('['), space0),
+            pair(char('['), multispace0),
             terminated(
                 map(parse_multi_selector, Segment::LongHand),
                 pair(
-                    space0,
+                    multispace0,
                     cut_with(char(']'), |_| SegmentError::ExpectedClosingBrace),
                 ),
             ),

--- a/serde_json_path/src/parser/selector/filter.rs
+++ b/serde_json_path/src/parser/selector/filter.rs
@@ -1,4 +1,4 @@
-use nom::character::complete::{char, space0};
+use nom::character::complete::{char, multispace0};
 use nom::combinator::{map, map_res};
 use nom::multi::separated_list1;
 use nom::sequence::{delimited, pair, preceded, separated_pair, tuple};
@@ -21,7 +21,7 @@ use crate::parser::{parse_query, PResult};
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 pub(crate) fn parse_filter(input: &str) -> PResult<Filter> {
     map(
-        preceded(pair(char('?'), space0), parse_logical_or_expr),
+        preceded(pair(char('?'), multispace0), parse_logical_or_expr),
         Filter,
     )(input)
 }
@@ -29,7 +29,10 @@ pub(crate) fn parse_filter(input: &str) -> PResult<Filter> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_logical_and(input: &str) -> PResult<LogicalAndExpr> {
     map(
-        separated_list1(tuple((space0, tag("&&"), space0)), parse_basic_expr),
+        separated_list1(
+            tuple((multispace0, tag("&&"), multispace0)),
+            parse_basic_expr,
+        ),
         LogicalAndExpr,
     )(input)
 }
@@ -37,7 +40,10 @@ fn parse_logical_and(input: &str) -> PResult<LogicalAndExpr> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 pub(crate) fn parse_logical_or_expr(input: &str) -> PResult<LogicalOrExpr> {
     map(
-        separated_list1(tuple((space0, tag("||"), space0)), parse_logical_and),
+        separated_list1(
+            tuple((multispace0, tag("||"), multispace0)),
+            parse_logical_and,
+        ),
         LogicalOrExpr,
     )(input)
 }
@@ -55,7 +61,7 @@ fn parse_exist_expr(input: &str) -> PResult<BasicExpr> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_not_exist_expr(input: &str) -> PResult<BasicExpr> {
     map(
-        preceded(pair(char('!'), space0), parse_exist_expr_inner),
+        preceded(pair(char('!'), multispace0), parse_exist_expr_inner),
         BasicExpr::NotExist,
     )(input)
 }
@@ -76,7 +82,7 @@ fn parse_func_expr(input: &str) -> PResult<BasicExpr> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_not_func_expr(input: &str) -> PResult<BasicExpr> {
     map(
-        preceded(pair(char('!'), space0), parse_func_expr_inner),
+        preceded(pair(char('!'), multispace0), parse_func_expr_inner),
         BasicExpr::NotFuncExpr,
     )(input)
 }
@@ -84,9 +90,9 @@ fn parse_not_func_expr(input: &str) -> PResult<BasicExpr> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_paren_expr_inner(input: &str) -> PResult<LogicalOrExpr> {
     delimited(
-        pair(char('('), space0),
+        pair(char('('), multispace0),
         parse_logical_or_expr,
-        pair(space0, char(')')),
+        pair(multispace0, char(')')),
     )(input)
 }
 
@@ -98,7 +104,7 @@ fn parse_paren_expr(input: &str) -> PResult<BasicExpr> {
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
 fn parse_not_parent_expr(input: &str) -> PResult<BasicExpr> {
     map(
-        preceded(pair(char('!'), space0), parse_paren_expr_inner),
+        preceded(pair(char('!'), multispace0), parse_paren_expr_inner),
         BasicExpr::NotParen,
     )(input)
 }
@@ -121,8 +127,8 @@ fn parse_comp_expr(input: &str) -> PResult<ComparisonExpr> {
     map(
         separated_pair(
             parse_comparable,
-            space0,
-            separated_pair(parse_comparison_operator, space0, parse_comparable),
+            multispace0,
+            separated_pair(parse_comparison_operator, multispace0, parse_comparable),
         ),
         |(left, (op, right))| ComparisonExpr { left, op, right },
     )(input)

--- a/serde_json_path/src/parser/selector/function/mod.rs
+++ b/serde_json_path/src/parser/selector/function/mod.rs
@@ -4,7 +4,7 @@ use nom::multi::separated_list0;
 use nom::sequence::{preceded, terminated};
 use nom::{
     branch::alt,
-    character::complete::{satisfy, space0},
+    character::complete::{multispace0, satisfy},
     combinator::map,
     multi::fold_many1,
     sequence::{delimited, pair},
@@ -70,12 +70,12 @@ pub(crate) fn parse_function_expr(input: &str) -> PResult<FunctionExpr<Validated
         pair(
             parse_function_name,
             delimited(
-                terminated(char('('), space0),
+                terminated(char('('), multispace0),
                 separated_list0(
-                    delimited(space0, char(','), space0),
+                    delimited(multispace0, char(','), multispace0),
                     parse_function_argument,
                 ),
-                preceded(space0, char(')')),
+                preceded(multispace0, char(')')),
             ),
         ),
         |(name, args)| {

--- a/serde_json_path/tests/compliance.rs
+++ b/serde_json_path/tests/compliance.rs
@@ -63,7 +63,7 @@ fn compliace_test_suite() {
 const TEST_CASE_N: usize = 303;
 
 #[test]
-// #[ignore = "this is only for testing individual CTS test cases as needed"]
+#[ignore = "this is only for testing individual CTS test cases as needed"]
 fn compliance_single() {
     let cts_json_str = fs::read_to_string("../jsonpath-compliance-test-suite/cts.json")
         .expect("read cts.json file");

--- a/serde_json_path/tests/compliance.rs
+++ b/serde_json_path/tests/compliance.rs
@@ -24,7 +24,6 @@ struct TestCase {
 }
 
 #[test]
-// #[ignore = "compliance will fail until function extensions are implemented"]
 fn compliace_test_suite() {
     let cts_json_str = fs::read_to_string("../jsonpath-compliance-test-suite/cts.json")
         .expect("read cts.json file");
@@ -61,10 +60,10 @@ fn compliace_test_suite() {
     }
 }
 
-const TEST_CASE_N: usize = 260;
+const TEST_CASE_N: usize = 303;
 
 #[test]
-#[ignore = "this is only for testing individual CTS test cases as needed"]
+// #[ignore = "this is only for testing individual CTS test cases as needed"]
 fn compliance_single() {
     let cts_json_str = fs::read_to_string("../jsonpath-compliance-test-suite/cts.json")
         .expect("read cts.json file");


### PR DESCRIPTION
The CTS was updated to include the latest tests that have been added since last update. This caused some breakages, which required changes to be fixed.

In general, the usage of `space0` nom parser was replaced with `multispace0` in order to support new lines in query strings.

This closes #42 .