### PR TITLE
[#41] Add a line briefly describing descendant operator in docs

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **documentation**: Add line describing Descendant Operator ([#53])
+
+[#53]: https://github.com/hiltontj/serde_json_path/pull/53
+
 # 0.6.2 (13 July 2023)
 
 * **fixed**: Fixed an issue in the evaluation of `SingularQuery`s that was producing false positive query results when relative singular queries, e.g., `@.bar`, were being used as comparables in a filter, e.g., `$.foo[?(@.bar == 'baz')]` ([#50])

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -172,7 +172,9 @@
 //! # }
 //! ```
 //!
-//! #### Recursive descent (`..`)
+//! #### Descendant Operator (`..`)
+//!
+//! JSONPath query segments following a descendant operator (`..`) will visit the input node and each of its [descendants][ietf-descendants-def].
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -193,8 +195,9 @@
 //! # }
 //! ```
 //!
-//! [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html
-//! [jp_selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-14.html#name-selectors-2
+//! [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-17.html
+//! [jp_selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-17.html#name-selectors-2
+//! [ietf-descendants-def]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-17.html#section-1.1-6.28.1
 
 #![warn(
     clippy::all,

--- a/serde_json_path/src/parser/mod.rs
+++ b/serde_json_path/src/parser/mod.rs
@@ -151,7 +151,7 @@ fn parse_current_query(input: &str) -> PResult<Query> {
 }
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
- fn parse_query(input: &str) -> PResult<Query> {
+fn parse_query(input: &str) -> PResult<Query> {
     alt((parse_root_query, parse_current_query))(input)
 }
 

--- a/serde_json_path/src/parser/mod.rs
+++ b/serde_json_path/src/parser/mod.rs
@@ -151,7 +151,7 @@ fn parse_current_query(input: &str) -> PResult<Query> {
 }
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
-pub(self) fn parse_query(input: &str) -> PResult<Query> {
+ fn parse_query(input: &str) -> PResult<Query> {
     alt((parse_root_query, parse_current_query))(input)
 }
 

--- a/serde_json_path/src/parser/primitive/string.rs
+++ b/serde_json_path/src/parser/primitive/string.rs
@@ -256,7 +256,7 @@ mod tests {
             Ok(("", String::from("te\"st")))
         );
         assert_eq!(
-            parse_string_literal(r#"'te\'st'"#),
+            parse_string_literal(r"'te\'st'"),
             Ok(("", String::from("te'st")))
         );
     }


### PR DESCRIPTION
This is part of #41

The Descendant Operator (`..`) section has had a line added briefly describing it and linking to the relevant definition in the JSONPath spec.