### PR TITLE
[#41] Add a better example to the Filter section in main docs

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **documentation**: Add line describing Descendant Operator ([#53])
+- **documentation**: Improve example in Filter section of main docs ([#54])
 
 [#53]: https://github.com/hiltontj/serde_json_path/pull/53
+[#54]: https://github.com/hiltontj/serde_json_path/pull/54
 
 # 0.6.2 (13 July 2023)
 

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -142,14 +142,18 @@
 //! # use serde_json::json;
 //! # use serde_json_path::JsonPath;
 //! # fn main() -> Result<(), serde_json_path::ParseError> {
-//! let value = json!([
-//!     { "title": "Great Expectations", "price": 10 },
-//!     { "title": "Tale of Two Cities", "price": 8 },
-//!     { "title": "David Copperfield", "price": 17 }
-//! ]);
-//! let path = JsonPath::parse("$[?@.price > $[0].price].title")?;
+//! let value = json!({
+//!     "threshold": 40,
+//!     "readings": [
+//!         { "val": 35, "msg": "foo" },
+//!         { "val": 40, "msg": "bar" },
+//!         { "val": 42, "msg": "biz" },
+//!         { "val": 48, "msg": "bop" },
+//!     ]
+//! });
+//! let path = JsonPath::parse("$.readings[? @.val > $.threshold ].msg")?;
 //! let nodes = path.query(&value).all();
-//! assert_eq!(nodes, vec!["David Copperfield"]);
+//! assert_eq!(nodes, vec!["biz", "bop"]);
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
This relates to #41 

An example that makes clearer usage of absolute paths via `$` in filters is provided.