### PR TITLE
[#60] Fix the `match` function to properly match full string

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **documentation**: Improve example in Filter Selector section of main docs ([#54])
 - **documentation**: Improve examples in Slice Slector section of main docs ([#55])
 - **documentation**: Other improvements to documentation ([#56])
+- **fixed**: Formulate the regex used by the `match` function to correctly handle regular expressions with leading or trailing `|` characters ([#61])
 
 [#53]: https://github.com/hiltontj/serde_json_path/pull/53
 [#54]: https://github.com/hiltontj/serde_json_path/pull/54
 [#55]: https://github.com/hiltontj/serde_json_path/pull/55
 [#56]: https://github.com/hiltontj/serde_json_path/pull/56
+[#61]: https://github.com/hiltontj/serde_json_path/pull/61
 
 # 0.6.2 (13 July 2023)
 

--- a/serde_json_path/src/parser/selector/function/registry.rs
+++ b/serde_json_path/src/parser/selector/function/registry.rs
@@ -46,7 +46,7 @@ fn count(nodes: NodesType) -> ValueType {
 #[serde_json_path_macros::register(name = "match", target = MATCH_FUNC)]
 fn match_func(value: ValueType, rgx: ValueType) -> LogicalType {
     match (value.as_value(), rgx.as_value()) {
-        (Some(Value::String(s)), Some(Value::String(r))) => Regex::new(format!("^{r}$").as_str())
+        (Some(Value::String(s)), Some(Value::String(r))) => Regex::new(format!("^({r})$").as_str())
             .map(|r| r.is_match(s))
             .map(Into::into)
             .unwrap_or_default(),

--- a/serde_json_path/tests/regressions.rs
+++ b/serde_json_path/tests/regressions.rs
@@ -11,3 +11,12 @@ fn issue_49() {
     let path = JsonPath::parse("$[?(@.a == 2)]").expect("parses JSONPath");
     assert!(path.query(&value).is_empty());
 }
+
+// This test is meant for issue #60, which can be found here:
+// https://github.com/hiltontj/serde_json_path/issues/60
+#[test]
+fn issue_60() {
+    let value = json!([{"foo": "bar"}, {"foo": "biz"}]);
+    let path = JsonPath::parse("$[? match(@.foo, '|')]").expect("parses JSONPath");
+    assert!(path.query(&value).is_empty());
+}


### PR DESCRIPTION
This PR closes #60. Parentheses were added to the formulated regex used by the `match` function to ensure full input string was being matched. A regression test was added to check for correct behaviour.