### PR TITLE
Release 0.6.3 (round 2)

### DIFF
--- a/serde_json_path/Cargo.toml
+++ b/serde_json_path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json_path"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 authors = ["Trevor Hilton <trevor.hilton@gmail.com>"]


### PR DESCRIPTION
The version number was not bumped in the `Cargo.toml` file.