### PR TITLE
Fix new lints in Rust 1.74

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **internal**: address new clippy lints in Rust 1.74 ([#70])
+
+[#70]: https://github.com/hiltontj/serde_json_path/pull/70
+
 # 0.6.4 (9 November 2023)
 
 - **added**: `is_empty`, `is_more_than_one`, and `as_more_than_one` methods to `ExactlyOneError` ([#65])

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -313,7 +313,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 

--- a/serde_json_path_core/CHANGELOG.md
+++ b/serde_json_path_core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **internal**: address new clippy lints in Rust 1.74 and update some tracing instrumentation ([#70])
+
+[#70]: https://github.com/hiltontj/serde_json_path/pull/70
+
 # 0.1.3 (9 November 2023)
 
 - **added**: `is_empty`, `is_more_than_one`, and `as_more_than_one` methods to `ExactlyOneError` ([#65])

--- a/serde_json_path_core/src/lib.rs
+++ b/serde_json_path_core/src/lib.rs
@@ -36,7 +36,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 

--- a/serde_json_path_core/src/spec/segment.rs
+++ b/serde_json_path_core/src/spec/segment.rs
@@ -57,7 +57,7 @@ impl Queryable for QuerySegment {
     }
 }
 
-#[cfg_attr(feature = "trace", tracing::instrument(name = "Query Path Segment", level = "trace", parent = None, ret))]
+#[cfg_attr(feature = "trace", tracing::instrument(name = "Descend", level = "trace", parent = None, ret))]
 fn descend<'b>(segment: &QuerySegment, current: &'b Value, root: &'b Value) -> Vec<&'b Value> {
     let mut query = Vec::new();
     if let Some(list) = current.as_array() {

--- a/serde_json_path_macros/CHANGELOG.md
+++ b/serde_json_path_macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **internal**: address new clippy lints in Rust 1.74 ([#70])
+
+[#70]: https://github.com/hiltontj/serde_json_path/pull/70
+
 # 0.1.1 (9 November 2023)
 
 - bump version for `serde_json_path_core` update

--- a/serde_json_path_macros/src/lib.rs
+++ b/serde_json_path_macros/src/lib.rs
@@ -37,7 +37,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
The `private_in_public` lint that was deprecated has been removed by this PR.

The `descend` method used to query descendent operators had its tracing instrumentation named properly.