### PR TITLE
Fix `clippy` lints for Rust 1.75

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **internal**: address new clippy lints in Rust 1.75 ([#75])
 - **internal**: address new clippy lints in Rust 1.74 ([#70])
 - **internal**: code clean-up ([#72])
 
 [#70]: https://github.com/hiltontj/serde_json_path/pull/70
 [#72]: https://github.com/hiltontj/serde_json_path/pull/72
+[#75]: https://github.com/hiltontj/serde_json_path/pull/75
 
 # 0.6.4 (9 November 2023)
 

--- a/serde_json_path_core/CHANGELOG.md
+++ b/serde_json_path_core/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **internal**: address new clippy lints in Rust 1.75 ([#75])
 - **internal**: address new clippy lints in Rust 1.74 and update some tracing instrumentation ([#70])
 - **internal**: code clean-up ([#72])
 
 [#70]: https://github.com/hiltontj/serde_json_path/pull/70
 [#72]: https://github.com/hiltontj/serde_json_path/pull/72
+[#75]: https://github.com/hiltontj/serde_json_path/pull/75
 
 # 0.1.3 (9 November 2023)
 

--- a/serde_json_path_core/src/node.rs
+++ b/serde_json_path_core/src/node.rs
@@ -42,7 +42,7 @@ impl<'a> NodeList<'a> {
         } else if self.0.len() > 1 {
             Err(AtMostOneError(self.0.len()))
         } else {
-            Ok(self.0.get(0).copied())
+            Ok(self.0.first().copied())
         }
     }
 
@@ -76,7 +76,7 @@ impl<'a> NodeList<'a> {
         } else if self.0.len() > 1 {
             Err(ExactlyOneError::MoreThanOne(self.0.len()))
         } else {
-            Ok(self.0.get(0).unwrap())
+            Ok(self.0.first().unwrap())
         }
     }
 
@@ -204,7 +204,7 @@ impl<'a> NodeList<'a> {
         if self.0.is_empty() || self.0.len() > 1 {
             None
         } else {
-            self.0.get(0).copied()
+            self.0.first().copied()
         }
     }
 }


### PR DESCRIPTION
Clippy fixes for 1.75