### PR TITLE
Keep track of traversed path and implement `JsonPath::query_path_and_value`

### DIFF
--- a/serde_json_path/src/path.rs
+++ b/serde_json_path/src/path.rs
@@ -4,7 +4,7 @@ use serde::{de::Visitor, Deserialize, Serialize};
 use serde_json::Value;
 use serde_json_path_core::{
     node::NodeList,
-    spec::query::{Query, Queryable},
+    spec::query::{Query, QueryResult, Queryable},
 };
 
 use crate::{parser::parse_query_main, ParseError};
@@ -73,7 +73,33 @@ impl JsonPath {
     /// # }
     /// ```
     pub fn query<'b>(&self, value: &'b Value) -> NodeList<'b> {
-        self.0.query(value, value).into()
+        self.0
+            .query(value, value, vec![])
+            .into_iter()
+            .map(|(_path, value)| value)
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    /// Query a [`serde_json_path_core::spec::query::QueryResult`] with each
+    /// match having a path as [`Vec<String>`] and value as
+    /// [`serde_json::Value`]
+    ///
+    /// # Example
+    /// ```rust
+    /// # use serde_json::json;
+    /// # use serde_json_path::JsonPath;
+    /// # fn main() -> Result<(), serde_json_path::ParseError> {
+    /// let path = JsonPath::parse("$.foo[::2]")?;
+    /// let value = json!({"foo": [1, 2, 3, 4]});
+    /// let result = path.query_path_and_value(&value);
+    /// assert_eq!(result[1].0, vec!["foo", "2"]);
+    /// assert_eq!(result[1].1, 3);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn query_path_and_value<'b>(&self, value: &'b Value) -> QueryResult<'b> {
+        self.0.query(value, value, vec![])
     }
 }
 

--- a/serde_json_path_core/src/spec/functions.rs
+++ b/serde_json_path_core/src/spec/functions.rs
@@ -581,11 +581,17 @@ impl FunctionExprArg {
     fn evaluate<'a, 'b: 'a>(&'a self, current: &'b Value, root: &'b Value) -> JsonPathValue<'a> {
         match self {
             FunctionExprArg::Literal(lit) => lit.into(),
-            FunctionExprArg::SingularQuery(q) => match q.eval_query(current, root) {
-                Some(n) => JsonPathValue::Node(n),
+            FunctionExprArg::SingularQuery(q) => match q.eval_query(current, root, vec![]) {
+                Some(n) => JsonPathValue::Node(n.1),
                 None => JsonPathValue::Nothing,
             },
-            FunctionExprArg::FilterQuery(q) => JsonPathValue::Nodes(q.query(current, root).into()),
+            FunctionExprArg::FilterQuery(q) => JsonPathValue::Nodes(
+                q.query(current, root, vec![])
+                    .into_iter()
+                    .map(|(_, nodes)| nodes)
+                    .collect::<Vec<_>>()
+                    .into(),
+            ),
             FunctionExprArg::LogicalExpr(l) => match l.test_filter(current, root) {
                 true => JsonPathValue::Logical(LogicalType::True),
                 false => JsonPathValue::Logical(LogicalType::False),


### PR DESCRIPTION
This PR makes it possible to include paths in query results.

A new `JsonPath::query_path_and_value` function is exposed to avoid breaking backwards compatibility with existing users of `JsonPath::query`. The return value is a `Vec<(Vec<String>, &Value)>` where the `Vec<String>` represents a list of traversed keys and indices to arrive at the `serde_json::Value`.

For example:

```rust
use serde_json::json;
use serde_json_path::JsonPath;

fn main() -> Result<(), serde_json_path::ParseError> {
  let path = JsonPath::parse("$.foo[::2]")?;
  let value = json!({"foo": [1, 2, 3, 4]});
  let result = path.query_path_and_value(&value);
  assert_eq!(result[1].0, vec!["foo", "2"]);
  assert_eq!(result[1].1, 3);
  Ok(())
}
```

This implementation surely has room for optimization - I was lazy and in a hurry and just passed owned `Vec<String>` types everywhere.

I am not very familiar with the more advanced features of JSON Paths, but I did verify that the implementation works correctly in basic cases (accessing object members by keys, array indexing, wildcards and such)