### PR TITLE
docs: refer to RFC 9535

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Trevor Hilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **docs**: update links to refer to RFC 9535 ([#81])
+
+[#81]: https://github.com/hiltontj/serde_json_path/pull/81
+
 # 0.6.5 (2 February 2024)
 
 ## Added: `NormalizedPath` and `PathElement` types ([#78])

--- a/serde_json_path/README.md
+++ b/serde_json_path/README.md
@@ -1,6 +1,6 @@
 # serde_json_path
 
-`serde_json_path` allows you to use [JSONPath][jsonpath] to query the [`serde_json::Value`][serde_json_value] type.
+`serde_json_path` allows you to use JSONPath ([RFC 9535][rfc]) to query the [`serde_json::Value`][serde_json_value] type.
 
 [![Build status](https://github.com/hiltontj/serde_json_path/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hiltontj/serde_json_path/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/serde_json_path)](https://crates.io/crates/serde_json_path)
@@ -9,7 +9,7 @@
 ## Learn More
 
 * See the [Crate Documentation][docs] for usage and examples.
-* See the [IETF JSONPath Specification][jp_spec] for more details about JSONPath and examples of its usage.
+* See the JSONPath standard ([RFC 9535][rfc]) for more details about JSONPath query syntax and examples of its usage.
 * Try it out in the [Sandbox](https://serdejsonpath.live)
 
 ## License
@@ -22,9 +22,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `serde_json_path` by you, shall be licensed as MIT, without any
 additional terms or conditions.
 
+[rfc]: https://www.rfc-editor.org/rfc/rfc9535.html
 [docs]: https://docs.rs/serde_json_path
-[jsonpath]: https://datatracker.ietf.org/wg/jsonpath/about/
 [serde_json_value]: https://docs.rs/serde_json/latest/serde_json/enum.Value.html
 [license]: https://github.com/hiltontj/serde_json_path/blob/main/LICENSE-MIT
-[jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html
 

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -1,12 +1,9 @@
 //! This crate allows you to use JSONPath queries to extract nodelists from a [`serde_json::Value`].
 //!
-//! The crate intends to adhere to the [IETF JSONPath specification][ietf-spec]. Check out the
-//! specification to read more about JSONPath, and to find many examples of its usage.
+//! The crate intends to adhere to the IETF JSONPath standard ([RFC 9535][rfc]). Check out the
+//! specification to read more about JSONPath query syntax and to find many examples of its usage.
 //!
-//! [ietf-spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html
-//!
-//! Please note that the specification has not yet been published as an RFC; therefore, this crate
-//! may evolve as JSONPath becomes standardized.
+//! [rfc]: https://www.rfc-editor.org/rfc/rfc9535.html
 //!
 //! # Features
 //!
@@ -83,10 +80,10 @@
 //! ## Querying for multiple nodes
 //!
 //! For queries that are expected to return zero or many nodes, use the [`all`][NodeList::all]
-//! method. There are several [selectors][ietf-selectors] in JSONPath whose combination can produce
+//! method. There are several [selectors][rfc-selectors] in JSONPath whose combination can produce
 //! useful and powerful queries.
 //!
-//! [ietf-selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html#name-selectors-2
+//! [rfc-selectors]: https://www.rfc-editor.org/rfc/rfc9535.html#name-selectors-2
 //!
 //! #### Wildcards (`*`)
 //!
@@ -198,12 +195,12 @@
 //!
 //! #### Filter expressions (`?`)
 //!
-//! [Filter selectors][ietf-filter-selectors] allow you to use logical expressions to evaluate which
+//! [Filter selectors][rfc-filter-selectors] allow you to use logical expressions to evaluate which
 //! members in a JSON object or array will be selected. You can use the boolean `&&` and `||`
 //! operators as well as parentheses to group logical expressions in your filters. The current node
 //! (`@`) operator allows you to utilize the node being filtered in your filter logic:
 //!
-//! [ietf-filter-selectors]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html#name-filter-selector
+//! [rfc-filter-selectors]: https://www.rfc-editor.org/rfc/rfc9535.html#name-filter-selector
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -260,9 +257,9 @@
 //!
 //! #### Descendant Operator (`..`)
 //!
-//! JSONPath query segments following a descendant operator (`..`) will visit the input node and each of its [descendants][ietf-descendants-def].
+//! JSONPath query segments following a descendant operator (`..`) will visit the input node and each of its [descendants][rfc-descendants-def].
 //!
-//! [ietf-descendants-def]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html#section-1.1-6.28.1
+//! [rfc-descendants-def]: https://www.rfc-editor.org/rfc/rfc9535.html#section-1.1-7.28.1
 //!
 //! ```rust
 //! # use serde_json::json;
@@ -385,7 +382,7 @@ pub use serde_json_path_core::node::{
 /// A [`NormalizedPath`] is used to represent the location of a node within a query result
 /// produced by the [`JsonPath::query_located`] method.
 ///
-/// [norm-path]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html#name-normalized-paths
+/// [norm-path]: https://www.rfc-editor.org/rfc/rfc9535.html#name-normalized-paths
 pub use serde_json_path_core::path::NormalizedPath;
 #[doc(inline)]
 pub use serde_json_path_core::path::PathElement;

--- a/serde_json_path/src/path.rs
+++ b/serde_json_path/src/path.rs
@@ -12,7 +12,7 @@ use crate::{parser::parse_query_main, ParseError};
 /// A parsed JSON Path query string
 ///
 /// This type represents a valid, parsed JSON Path query string. Please refer to the
-/// [IETF JSONPath specification][jp_spec] for the details on what constitutes a valid JSON Path
+/// JSONPath ([RFC 9535][rfc]) for the details on what constitutes a valid JSON Path
 /// query.
 ///
 /// # Usage
@@ -36,7 +36,7 @@ use crate::{parser::parse_query_main, ParseError};
 /// # }
 /// ```
 ///
-/// [jp_spec]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-10.html
+/// [rfc]: https://www.rfc-editor.org/rfc/rfc9535.html
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct JsonPath(Query);
 

--- a/serde_json_path/src/path.rs
+++ b/serde_json_path/src/path.rs
@@ -12,7 +12,7 @@ use crate::{parser::parse_query_main, ParseError};
 /// A parsed JSON Path query string
 ///
 /// This type represents a valid, parsed JSON Path query string. Please refer to the
-/// JSONPath ([RFC 9535][rfc]) for the details on what constitutes a valid JSON Path
+/// JSONPath standard ([RFC 9535][rfc]) for the details on what constitutes a valid JSON Path
 /// query.
 ///
 /// # Usage

--- a/serde_json_path_core/CHANGELOG.md
+++ b/serde_json_path_core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **docs**: update links to refer to RFC 9535 ([#81])
+
+[#81]: https://github.com/hiltontj/serde_json_path/pull/81
+
 # 0.1.4 (2 February 2024)
 
 ## Added: `NormalizedPath` and `PathElement` types ([#78])

--- a/serde_json_path_core/src/path.rs
+++ b/serde_json_path_core/src/path.rs
@@ -1,6 +1,6 @@
 //! Types for representing [Normalized Paths][norm-paths] from the JSONPath specification
 //!
-//! [norm-paths]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html#name-normalized-paths
+//! [norm-paths]: https://www.rfc-editor.org/rfc/rfc9535.html#name-normalized-paths
 use std::{
     cmp::Ordering,
     fmt::Display,
@@ -187,7 +187,7 @@ impl<'a> Display for NormalizedPath<'a> {
     /// # }
     /// ```
     ///
-    /// [norm-paths]: https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-21.html#name-normalized-paths
+    /// [norm-paths]: https://www.rfc-editor.org/rfc/rfc9535.html#name-normalized-paths
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "$")?;
         for elem in &self.0 {

--- a/serde_json_path_core/src/spec/functions.rs
+++ b/serde_json_path_core/src/spec/functions.rs
@@ -1,8 +1,10 @@
 //! Function Extensions in JSONPath
 //!
-//! Function Extensions in JSONPath serve as a way to extend the capability of queries in a way that
+//! [Function Extensions][func-ext] in JSONPath serve as a way to extend the capability of queries in a way that
 //! the standard query syntax can not support. There are various functions included in JSONPath, all
 //! of which conform to a specified type system.
+//!
+//! [func-ext]: https://www.rfc-editor.org/rfc/rfc9535.html#name-function-extensions
 //!
 //! # The JSONPath Type System
 //!


### PR DESCRIPTION
This PR updates links to refer to the new JSONPath standard ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html))