### PR TITLE
fix: use CRLF mode in regexes for match and search

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **fixed**: edge case where `.` in regexes for `match` and `search` functions was matching `\r\n` properly ([#92])
+
+[#92]: https://github.com/hiltontj/serde_json_path/pull/92
+
 # 0.6.7 (3 March 2024)
 
 - **testing**: support tests for non-determinism in compliance test suite ([#85])

--- a/serde_json_path/src/parser/selector/function/registry.rs
+++ b/serde_json_path/src/parser/selector/function/registry.rs
@@ -53,10 +53,12 @@ fn count(nodes: NodesType) -> ValueType {
 #[serde_json_path_macros::register(name = "match", target = MATCH_FUNC)]
 fn match_func(value: ValueType, rgx: ValueType) -> LogicalType {
     match (value.as_value(), rgx.as_value()) {
-        (Some(Value::String(s)), Some(Value::String(r))) => Regex::new(format!("^({r})$").as_str())
-            .map(|r| r.is_match(s))
-            .map(Into::into)
-            .unwrap_or_default(),
+        (Some(Value::String(s)), Some(Value::String(r))) => {
+            Regex::new(format!("(?R)^({r})$").as_str())
+                .map(|r| r.is_match(s))
+                .map(Into::into)
+                .unwrap_or_default()
+        }
         _ => LogicalType::False,
     }
 }
@@ -64,10 +66,12 @@ fn match_func(value: ValueType, rgx: ValueType) -> LogicalType {
 #[serde_json_path_macros::register(target = SEARCH_FUNC)]
 fn search(value: ValueType, rgx: ValueType) -> LogicalType {
     match (value.as_value(), rgx.as_value()) {
-        (Some(Value::String(s)), Some(Value::String(r))) => Regex::new(r.as_str())
-            .map(|r| r.is_match(s))
-            .map(Into::into)
-            .unwrap_or_default(),
+        (Some(Value::String(s)), Some(Value::String(r))) => {
+            Regex::new(format!("(?R)({r})").as_str())
+                .map(|r| r.is_match(s))
+                .map(Into::into)
+                .unwrap_or_default()
+        }
         _ => LogicalType::False,
     }
 }


### PR DESCRIPTION
Update after latest CTS surfaced an edge case for i-regexp compliance.

Use [CRLF mode](https://docs.rs/regex/latest/regex/#grouping-and-flags) in regexes for search and match functions so that the line feed and new line characters are treated properly with a dot matcher

Closes #90