### PR TITLE
feat: Add `regex` feature flag

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed**: edge case where `.` in regexes for `match` and `search` functions was matching `\r\n` properly ([#92])
+- **breaking**: added `regex` feature flag that gates regex functions `match` and `search`
+    - Feature is enabled by default, but if you have `default-features = false` you'll need to explicitly add it to retain access to these functions
 
 [#92]: https://github.com/hiltontj/serde_json_path/pull/92
 

--- a/serde_json_path/Cargo.toml
+++ b/serde_json_path/Cargo.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 keywords = ["json", "jsonpath", "json_path", "serde", "serde_json"]
 
 [features]
-default = ["functions"]
+default = ["functions", "regex"]
+regex = ["dep:regex"]
 trace = ["dep:tracing", "serde_json_path_core/trace"]
 functions = ["serde_json_path_core/functions"]
 
@@ -19,7 +20,7 @@ functions = ["serde_json_path_core/functions"]
 inventory = { version = "0.3.4" }
 nom = "7.1.3"
 once_cell = { version = "1.17.1" }
-regex = "1.7.1"
+regex = { version="1.7.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_json_path_core = { path = "../serde_json_path_core", version = "0.1.6" }

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -316,7 +316,7 @@
 //!
 //! The following feature flags are supported:
 //!
-//! - `tracing` - Enable internal tracing via [tracing]
+//! - `tracing` - Enable internal tracing via [tracing](https://docs.rs/tracing/latest/tracing/)
 //! - `functions` - Enable user-defined functions
 //! - `regex` - Enable the `match` and `search` functions
 

--- a/serde_json_path/src/lib.rs
+++ b/serde_json_path/src/lib.rs
@@ -311,6 +311,14 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Feature Flags
+//!
+//! The following feature flags are supported:
+//!
+//! - `tracing` - Enable internal tracing via [tracing]
+//! - `functions` - Enable user-defined functions
+//! - `regex` - Enable the `match` and `search` functions
 
 #![warn(
     clippy::all,


### PR DESCRIPTION
First off, love this library, thanks for it. For my use case I don't really need the regex functions, and it's a really large dependency to pull in (adds ~8s to my build process).

This change hides the regex functions (`match` and `search`) behind a feature flag `regex`, which is enabled by default. This allows consumers to completely eliminate regex as a dependency if they choose. Also added some docs on feature flags.

I wasn't sure if I should update the changelog since it looks like it might be auto-generated from git cliff, let me know what you'd like.