### PR TITLE
Enable Dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
As discussed in https://github.com/hiltontj/serde_json_path/pull/94#issuecomment-2266471331

You can also enable Dependabot for the Rust dependencies (but I haven't done that before with Cargo Workspaces). And you can also customize Dependabot in multiple ways, such as grouping update pull requests, ignoring certain dependencies, ignoring patch version updates, ...