### PR TITLE
feat: implement integer type to comply with spec

### DIFF
--- a/serde_json_path/CHANGELOG.md
+++ b/serde_json_path/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed**: edge case where `.` in regexes for `match` and `search` functions was matching `\r\n` properly ([#92])
 - **breaking**: added `regex` feature flag that gates regex functions `match` and `search`
     - Feature is enabled by default, but if you have `default-features = false` you'll need to explicitly add it to retain access to these functions
+- **breaking**(`serde_json_path_core`): ensure integers used as indices are within the [valid range for I-JSON][i-json-range] ([#98])
 
 [#92]: https://github.com/hiltontj/serde_json_path/pull/92
+[#98]: https://github.com/hiltontj/serde_json_path/pull/98
+[i-json-range]: https://www.rfc-editor.org/rfc/rfc9535.html#section-2.1-4.1
 
 # 0.6.7 (3 March 2024)
 

--- a/serde_json_path/src/parser/primitive/int.rs
+++ b/serde_json_path/src/parser/primitive/int.rs
@@ -6,6 +6,7 @@ use nom::{
     combinator::{map_res, opt, recognize},
     sequence::tuple,
 };
+use serde_json_path_core::spec::integer::Integer;
 
 use crate::parser::PResult;
 
@@ -37,19 +38,30 @@ pub(crate) fn parse_int_string(input: &str) -> PResult<&str> {
 }
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
-pub(crate) fn parse_int(input: &str) -> PResult<isize> {
-    map_res(parse_int_string, |i_str| i_str.parse::<isize>())(input)
+pub(crate) fn parse_int(input: &str) -> PResult<Integer> {
+    map_res(parse_int_string, |i_str| i_str.parse())(input)
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json_path_core::spec::integer::Integer;
+
     use crate::parser::primitive::int::parse_int;
 
     #[test]
     fn parse_integers() {
-        assert_eq!(parse_int("0"), Ok(("", 0)));
-        assert_eq!(parse_int("10"), Ok(("", 10)));
-        assert_eq!(parse_int("-10"), Ok(("", -10)));
-        assert_eq!(parse_int("010"), Ok(("10", 0)));
+        assert_eq!(parse_int("0"), Ok(("", Integer::from_i64_opt(0).unwrap())));
+        assert_eq!(
+            parse_int("10"),
+            Ok(("", Integer::from_i64_opt(10).unwrap()))
+        );
+        assert_eq!(
+            parse_int("-10"),
+            Ok(("", Integer::from_i64_opt(-10).unwrap()))
+        );
+        assert_eq!(
+            parse_int("010"),
+            Ok(("10", Integer::from_i64_opt(0).unwrap()))
+        );
     }
 }

--- a/serde_json_path/src/parser/primitive/int.rs
+++ b/serde_json_path/src/parser/primitive/int.rs
@@ -50,18 +50,9 @@ mod tests {
 
     #[test]
     fn parse_integers() {
-        assert_eq!(parse_int("0"), Ok(("", Integer::from_i64_opt(0).unwrap())));
-        assert_eq!(
-            parse_int("10"),
-            Ok(("", Integer::from_i64_opt(10).unwrap()))
-        );
-        assert_eq!(
-            parse_int("-10"),
-            Ok(("", Integer::from_i64_opt(-10).unwrap()))
-        );
-        assert_eq!(
-            parse_int("010"),
-            Ok(("10", Integer::from_i64_opt(0).unwrap()))
-        );
+        assert_eq!(parse_int("0"), Ok(("", Integer::from_i64_unchecked(0))));
+        assert_eq!(parse_int("10"), Ok(("", Integer::from_i64_unchecked(10))));
+        assert_eq!(parse_int("-10"), Ok(("", Integer::from_i64_unchecked(-10))));
+        assert_eq!(parse_int("010"), Ok(("10", Integer::from_i64_unchecked(0))));
     }
 }

--- a/serde_json_path/src/parser/segment.rs
+++ b/serde_json_path/src/parser/segment.rs
@@ -150,7 +150,10 @@ mod tests {
     use test_log::test;
 
     use nom::combinator::all_consuming;
-    use serde_json_path_core::spec::selector::{index::Index, name::Name, slice::Slice, Selector};
+    use serde_json_path_core::spec::{
+        integer::Integer,
+        selector::{index::Index, name::Name, slice::Slice, Selector},
+    };
 
     use super::{
         parse_child_long_hand, parse_child_segment, parse_descendant_segment,
@@ -194,7 +197,10 @@ mod tests {
             let (_, sk) = parse_child_long_hand(r#"['name',10,0:3]"#).unwrap();
             let s = sk.as_long_hand().unwrap();
             assert_eq!(s[0], Selector::Name(Name::from("name")));
-            assert_eq!(s[1], Selector::Index(Index(10)));
+            assert_eq!(
+                s[1],
+                Selector::Index(Index(Integer::from_i64_opt(10).unwrap()))
+            );
             assert_eq!(
                 s[2],
                 Selector::ArraySlice(Slice::new().with_start(0).with_end(3))

--- a/serde_json_path/src/parser/segment.rs
+++ b/serde_json_path/src/parser/segment.rs
@@ -199,7 +199,7 @@ mod tests {
             assert_eq!(s[0], Selector::Name(Name::from("name")));
             assert_eq!(
                 s[1],
-                Selector::Index(Index(Integer::from_i64_opt(10).unwrap()))
+                Selector::Index(Index(Integer::from_i64_unchecked(10)))
             );
             assert_eq!(
                 s[2],

--- a/serde_json_path/src/parser/selector/mod.rs
+++ b/serde_json_path/src/parser/selector/mod.rs
@@ -87,14 +87,11 @@ mod tests {
     fn all_selectors() {
         {
             let (_, s) = parse_selector("0").unwrap();
-            assert_eq!(s, Selector::Index(Index(Integer::from_i64_opt(0).unwrap())));
+            assert_eq!(s, Selector::Index(Index(Integer::from_i64_unchecked(0))));
         }
         {
             let (_, s) = parse_selector("10").unwrap();
-            assert_eq!(
-                s,
-                Selector::Index(Index(Integer::from_i64_opt(10).unwrap()))
-            );
+            assert_eq!(s, Selector::Index(Index(Integer::from_i64_unchecked(10))));
         }
         {
             let (_, s) = parse_selector("'name'").unwrap();

--- a/serde_json_path/src/parser/selector/mod.rs
+++ b/serde_json_path/src/parser/selector/mod.rs
@@ -68,7 +68,10 @@ pub(crate) fn parse_selector(input: &str) -> PResult<Selector> {
 
 #[cfg(test)]
 mod tests {
-    use serde_json_path_core::spec::selector::{name::Name, slice::Slice};
+    use serde_json_path_core::spec::{
+        integer::Integer,
+        selector::{name::Name, slice::Slice},
+    };
 
     use super::{parse_selector, parse_wildcard_selector, Index, Selector};
 
@@ -84,11 +87,14 @@ mod tests {
     fn all_selectors() {
         {
             let (_, s) = parse_selector("0").unwrap();
-            assert_eq!(s, Selector::Index(Index(0)));
+            assert_eq!(s, Selector::Index(Index(Integer::from_i64_opt(0).unwrap())));
         }
         {
             let (_, s) = parse_selector("10").unwrap();
-            assert_eq!(s, Selector::Index(Index(10)));
+            assert_eq!(
+                s,
+                Selector::Index(Index(Integer::from_i64_opt(10).unwrap()))
+            );
         }
         {
             let (_, s) = parse_selector("'name'").unwrap();

--- a/serde_json_path/src/parser/selector/slice.rs
+++ b/serde_json_path/src/parser/selector/slice.rs
@@ -4,17 +4,17 @@ use nom::{
     combinator::{map, opt},
     sequence::{preceded, separated_pair, terminated},
 };
-use serde_json_path_core::spec::selector::slice::Slice;
+use serde_json_path_core::spec::{integer::Integer, selector::slice::Slice};
 
 use crate::parser::{primitive::int::parse_int, PResult};
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
-fn parse_int_space_after(input: &str) -> PResult<isize> {
+fn parse_int_space_after(input: &str) -> PResult<Integer> {
     terminated(parse_int, multispace0)(input)
 }
 
 #[cfg_attr(feature = "trace", tracing::instrument(level = "trace", parent = None, ret, err))]
-fn parse_int_space_before(input: &str) -> PResult<isize> {
+fn parse_int_space_before(input: &str) -> PResult<Integer> {
     preceded(multispace0, parse_int)(input)
 }
 

--- a/serde_json_path_core/CHANGELOG.md
+++ b/serde_json_path_core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **breaking**: ensure integers used as indices are within the [valid range for I-JSON][i-json-range] ([#98])
+
+[#98]: https://github.com/hiltontj/serde_json_path/pull/98
+[i-json-range]: https://www.rfc-editor.org/rfc/rfc9535.html#section-2.1-4.1
+
 # 0.1.6 (3 March 2024)
 
 - **testing**: support tests for non-determinism in compliance test suite ([#85])

--- a/serde_json_path_core/src/spec/integer.rs
+++ b/serde_json_path_core/src/spec/integer.rs
@@ -1,0 +1,120 @@
+//! Representation of itegers in the JSONPath specification
+//!
+//! The JSONPath specification defines some rules for integers used in query strings (see [here][spec]).
+//!
+//! [spec]: https://www.rfc-editor.org/rfc/rfc9535.html#name-overview
+
+use std::{
+    num::{ParseIntError, TryFromIntError},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Integer(i64);
+
+const MAX: i64 = 9_007_199_254_740_992 - 1;
+const MIN: i64 = -9_007_199_254_740_992 + 1;
+
+impl Integer {
+    fn try_new(value: i64) -> Result<Self, IntegerError> {
+        if value < MIN || value > MAX {
+            return Err(IntegerError::OutOfBounds);
+        } else {
+            return Ok(Self(value));
+        }
+    }
+
+    fn check(&self) -> bool {
+        self.0 >= MIN && self.0 <= MAX
+    }
+
+    pub fn from_i64_opt(value: i64) -> Option<Self> {
+        Self::try_new(value).ok()
+    }
+
+    pub fn checked_abs(mut self) -> Option<Self> {
+        self.0 = self.0.checked_abs()?;
+        self.check().then_some(self)
+    }
+
+    pub fn checked_add(mut self, rhs: Self) -> Option<Self> {
+        self.0 = self.0.checked_add(rhs.0)?;
+        self.check().then_some(self)
+    }
+
+    pub fn checked_sub(mut self, rhs: Self) -> Option<Self> {
+        self.0 = self.0.checked_sub(rhs.0)?;
+        self.check().then_some(self)
+    }
+
+    pub fn checked_mul(mut self, rhs: Self) -> Option<Self> {
+        self.0 = self.0.checked_mul(rhs.0)?;
+        self.check().then_some(self)
+    }
+}
+
+impl Default for Integer {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl TryFrom<i64> for Integer {
+    type Error = IntegerError;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl TryFrom<usize> for Integer {
+    type Error = IntegerError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        i64::try_from(value)
+            .map_err(|_| IntegerError::OutOfBounds)
+            .and_then(Self::try_new)
+    }
+}
+
+impl FromStr for Integer {
+    type Err = IntegerError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<i64>().map_err(Into::into).and_then(Self::try_new)
+    }
+}
+
+impl std::fmt::Display for Integer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<Integer> for usize {
+    type Error = TryFromIntError;
+
+    fn try_from(value: Integer) -> Result<Self, Self::Error> {
+        Self::try_from(value.0)
+    }
+}
+
+impl PartialEq<i64> for Integer {
+    fn eq(&self, other: &i64) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<i64> for Integer {
+    fn partial_cmp(&self, other: &i64) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IntegerError {
+    #[error("the provided integer was outside the valid range, see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.1-4.1")]
+    OutOfBounds,
+    #[error(transparent)]
+    Parse(#[from] ParseIntError),
+}

--- a/serde_json_path_core/src/spec/integer.rs
+++ b/serde_json_path_core/src/spec/integer.rs
@@ -9,10 +9,17 @@ use std::{
     str::FromStr,
 };
 
+/// An integer for internet JSON ([RFC7493][ijson])
+///
+/// The value must be within the range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
+///
+/// [ijson]: https://www.rfc-editor.org/rfc/rfc7493#section-2.2
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Integer(i64);
 
+/// The maximum allowed value, 2^53 - 1
 const MAX: i64 = 9_007_199_254_740_992 - 1;
+/// The minimum allowed value (-2^53) + 1
 const MIN: i64 = -9_007_199_254_740_992 + 1;
 
 impl Integer {
@@ -28,25 +35,37 @@ impl Integer {
         self.0 >= MIN && self.0 <= MAX
     }
 
+    /// Get an [`Integer`] from an `i64`
+    ///
+    /// This will produce `None` if the inputted value is out of the valid range
+    /// [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
     pub fn from_i64_opt(value: i64) -> Option<Self> {
         Self::try_new(value).ok()
     }
 
+    /// Take the absolute value, producing `None` if the resulting value is outside
+    /// the valid range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
     pub fn checked_abs(mut self) -> Option<Self> {
         self.0 = self.0.checked_abs()?;
         self.check().then_some(self)
     }
 
+    /// Add the two values, producing `None` if the resulting value is outside the
+    /// valid range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
     pub fn checked_add(mut self, rhs: Self) -> Option<Self> {
         self.0 = self.0.checked_add(rhs.0)?;
         self.check().then_some(self)
     }
 
+    /// Subtract the `rhs` from `self`, producing `None` if the resulting value is
+    /// outside the valid range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
     pub fn checked_sub(mut self, rhs: Self) -> Option<Self> {
         self.0 = self.0.checked_sub(rhs.0)?;
         self.check().then_some(self)
     }
 
+    /// Multiply the two values, producing `None` if the resulting value is outside
+    /// the valid range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
     pub fn checked_mul(mut self, rhs: Self) -> Option<Self> {
         self.0 = self.0.checked_mul(rhs.0)?;
         self.check().then_some(self)
@@ -111,10 +130,13 @@ impl PartialOrd<i64> for Integer {
     }
 }
 
+/// An error for the [`Integer`] type
 #[derive(Debug, thiserror::Error)]
 pub enum IntegerError {
+    /// The provided value was outside the valid range [-(2**53)+1, (2**53)-1])
     #[error("the provided integer was outside the valid range, see https://www.rfc-editor.org/rfc/rfc9535.html#section-2.1-4.1")]
     OutOfBounds,
+    /// Integer parsing error
     #[error(transparent)]
     Parse(#[from] ParseIntError),
 }

--- a/serde_json_path_core/src/spec/integer.rs
+++ b/serde_json_path_core/src/spec/integer.rs
@@ -35,12 +35,21 @@ impl Integer {
         (MIN..=MAX).contains(&self.0)
     }
 
+    /// Produce an [`Integer`] with the value 0
+    pub fn zero() -> Self {
+        Self(0)
+    }
+
     /// Get an [`Integer`] from an `i64`
     ///
-    /// This will produce `None` if the inputted value is out of the valid range
+    /// This is intended for initializing an integer with small, non-zero numbers.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the inputted value is out of the valid range
     /// [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
-    pub fn from_i64_opt(value: i64) -> Option<Self> {
-        Self::try_new(value).ok()
+    pub fn from_i64_unchecked(value: i64) -> Self {
+        Self::try_new(value).expect("value is out of the valid range")
     }
 
     /// Take the absolute value, producing `None` if the resulting value is outside

--- a/serde_json_path_core/src/spec/integer.rs
+++ b/serde_json_path_core/src/spec/integer.rs
@@ -14,7 +14,7 @@ use std::{
 /// The value must be within the range [-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1]).
 ///
 /// [ijson]: https://www.rfc-editor.org/rfc/rfc7493#section-2.2
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Integer(i64);
 
 /// The maximum allowed value, 2^53 - 1
@@ -24,15 +24,15 @@ const MIN: i64 = -9_007_199_254_740_992 + 1;
 
 impl Integer {
     fn try_new(value: i64) -> Result<Self, IntegerError> {
-        if value < MIN || value > MAX {
-            return Err(IntegerError::OutOfBounds);
+        if !(MIN..=MAX).contains(&value) {
+            Err(IntegerError::OutOfBounds)
         } else {
-            return Ok(Self(value));
+            Ok(Self(value))
         }
     }
 
     fn check(&self) -> bool {
-        self.0 >= MIN && self.0 <= MAX
+        (MIN..=MAX).contains(&self.0)
     }
 
     /// Get an [`Integer`] from an `i64`
@@ -69,12 +69,6 @@ impl Integer {
     pub fn checked_mul(mut self, rhs: Self) -> Option<Self> {
         self.0 = self.0.checked_mul(rhs.0)?;
         self.check().then_some(self)
-    }
-}
-
-impl Default for Integer {
-    fn default() -> Self {
-        Self(0)
     }
 }
 

--- a/serde_json_path_core/src/spec/mod.rs
+++ b/serde_json_path_core/src/spec/mod.rs
@@ -1,5 +1,6 @@
 //! Types representing the IETF JSONPath Standard
 pub mod functions;
+pub mod integer;
 pub mod query;
 pub mod segment;
 pub mod selector;

--- a/serde_json_path_core/src/spec/selector/index.rs
+++ b/serde_json_path_core/src/spec/selector/index.rs
@@ -69,9 +69,3 @@ impl Queryable for Index {
         }
     }
 }
-
-// impl From<isize> for Index {
-//     fn from(i: isize) -> Self {
-//         Self(i)
-//     }
-// }

--- a/serde_json_path_core/src/spec/selector/index.rs
+++ b/serde_json_path_core/src/spec/selector/index.rs
@@ -1,13 +1,17 @@
 //! Index selectors in JSONPath
 use serde_json::Value;
 
-use crate::{node::LocatedNode, path::NormalizedPath, spec::query::Queryable};
+use crate::{
+    node::LocatedNode,
+    path::NormalizedPath,
+    spec::{integer::Integer, query::Queryable},
+};
 
 /// For selecting array elements by their index
 ///
 /// Can use negative indices to index from the end of an array
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct Index(pub isize);
+pub struct Index(pub Integer);
 
 impl std::fmt::Display for Index {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -66,8 +70,8 @@ impl Queryable for Index {
     }
 }
 
-impl From<isize> for Index {
-    fn from(i: isize) -> Self {
-        Self(i)
-    }
-}
+// impl From<isize> for Index {
+//     fn from(i: isize) -> Self {
+//         Self(i)
+//     }
+// }

--- a/serde_json_path_core/src/spec/selector/slice.rs
+++ b/serde_json_path_core/src/spec/selector/slice.rs
@@ -50,17 +50,17 @@ impl Slice {
     }
 
     pub fn with_start(mut self, start: i64) -> Self {
-        self.start = Integer::from_i64_opt(start);
+        self.start = Some(Integer::from_i64_opt(start).expect("valid start"));
         self
     }
 
     pub fn with_end(mut self, end: i64) -> Self {
-        self.end = Integer::from_i64_opt(end);
+        self.end = Some(Integer::from_i64_opt(end).expect("valid end"));
         self
     }
 
     pub fn with_step(mut self, step: i64) -> Self {
-        self.step = Integer::from_i64_opt(step);
+        self.step = Some(Integer::from_i64_opt(step).expect("valid step"));
         self
     }
 

--- a/serde_json_path_core/src/spec/selector/slice.rs
+++ b/serde_json_path_core/src/spec/selector/slice.rs
@@ -1,7 +1,11 @@
 //! Slice selectors for selecting array slices in JSONPath
 use serde_json::Value;
 
-use crate::{node::LocatedNode, path::NormalizedPath, spec::query::Queryable};
+use crate::{
+    node::LocatedNode,
+    path::NormalizedPath,
+    spec::{integer::Integer, query::Queryable},
+};
 
 /// A slice selector
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
@@ -10,16 +14,16 @@ pub struct Slice {
     ///
     /// This can be negative to start the slice from a position relative to the end of the array
     /// being sliced.
-    pub start: Option<isize>,
+    pub start: Option<Integer>,
     /// The end of the slice
     ///
     /// This can be negative to end the slice at a position relative to the end of the array being
     /// sliced.
-    pub end: Option<isize>,
+    pub end: Option<Integer>,
     /// The step slice for the slice
     ///
     /// This can be negative to step in reverse order.
-    pub step: Option<isize>,
+    pub step: Option<Integer>,
 }
 
 impl std::fmt::Display for Slice {
@@ -45,46 +49,59 @@ impl Slice {
         Self::default()
     }
 
-    pub fn with_start(mut self, start: isize) -> Self {
-        self.start = Some(start);
+    pub fn with_start(mut self, start: i64) -> Self {
+        self.start = Integer::from_i64_opt(start);
         self
     }
 
-    pub fn with_end(mut self, end: isize) -> Self {
-        self.end = Some(end);
+    pub fn with_end(mut self, end: i64) -> Self {
+        self.end = Integer::from_i64_opt(end);
         self
     }
 
-    pub fn with_step(mut self, step: isize) -> Self {
-        self.step = Some(step);
+    pub fn with_step(mut self, step: i64) -> Self {
+        self.step = Integer::from_i64_opt(step);
         self
     }
 
     #[inline]
-    fn bounds_on_forward_slice(&self, len: isize) -> (isize, isize) {
-        let start_default = self.start.unwrap_or(0);
+    fn bounds_on_forward_slice(&self, len: Integer) -> (Integer, Integer) {
+        let start_default = self.start.unwrap_or_default();
         let end_default = self.end.unwrap_or(len);
         let start = normalize_slice_index(start_default, len)
-            .unwrap_or(0)
-            .max(0);
-        let end = normalize_slice_index(end_default, len).unwrap_or(0).max(0);
+            .unwrap_or_default()
+            .max(Integer::default());
+        let end = normalize_slice_index(end_default, len)
+            .unwrap_or_default()
+            .max(Integer::default());
         let lower = start.min(len);
         let upper = end.min(len);
         (lower, upper)
     }
 
     #[inline]
-    fn bounds_on_reverse_slice(&self, len: isize) -> Option<(isize, isize)> {
-        let start_default = self.start.or_else(|| len.checked_sub(1))?;
-        let end_default = self
-            .end
-            .or_else(|| len.checked_mul(-1).and_then(|l| l.checked_sub(1)))?;
+    fn bounds_on_reverse_slice(&self, len: Integer) -> Option<(Integer, Integer)> {
+        let start_default = self
+            .start
+            .or_else(|| Integer::from_i64_opt(1).and_then(|i| len.checked_sub(i)))?;
+        let end_default = self.end.or_else(|| {
+            let l = len.checked_mul(Integer::from_i64_opt(-1).unwrap())?;
+            l.checked_sub(Integer::from_i64_opt(1).unwrap())
+        })?;
         let start = normalize_slice_index(start_default, len)
-            .unwrap_or(0)
-            .max(-1);
-        let end = normalize_slice_index(end_default, len).unwrap_or(0).max(-1);
-        let lower = end.min(len.checked_sub(1).unwrap_or(len));
-        let upper = start.min(len.checked_sub(1).unwrap_or(len));
+            .unwrap_or_default()
+            .max(Integer::from_i64_opt(-1).unwrap());
+        let end = normalize_slice_index(end_default, len)
+            .unwrap_or_default()
+            .max(Integer::from_i64_opt(-1).unwrap());
+        let lower = end.min(
+            len.checked_sub(Integer::from_i64_opt(1).unwrap())
+                .unwrap_or(len),
+        );
+        let upper = start.min(
+            len.checked_sub(Integer::from_i64_opt(1).unwrap())
+                .unwrap_or(len),
+        );
         Some((lower, upper))
     }
 }
@@ -94,11 +111,11 @@ impl Queryable for Slice {
     fn query<'b>(&self, current: &'b Value, _root: &'b Value) -> Vec<&'b Value> {
         if let Some(list) = current.as_array() {
             let mut query = Vec::new();
-            let step = self.step.unwrap_or(1);
+            let step = self.step.unwrap_or(Integer::from_i64_opt(1).unwrap());
             if step == 0 {
                 return vec![];
             }
-            let Ok(len) = isize::try_from(list.len()) else {
+            let Ok(len) = Integer::try_from(list.len()) else {
                 return vec![];
             };
             if step > 0 {
@@ -108,7 +125,11 @@ impl Queryable for Slice {
                     if let Some(v) = usize::try_from(i).ok().and_then(|i| list.get(i)) {
                         query.push(v);
                     }
-                    i += step;
+                    i = if let Some(i) = i.checked_add(step) {
+                        i
+                    } else {
+                        break;
+                    };
                 }
             } else {
                 let Some((lower, upper)) = self.bounds_on_reverse_slice(len) else {
@@ -119,7 +140,11 @@ impl Queryable for Slice {
                     if let Some(v) = usize::try_from(i).ok().and_then(|i| list.get(i)) {
                         query.push(v);
                     }
-                    i += step;
+                    i = if let Some(i) = i.checked_add(step) {
+                        i
+                    } else {
+                        break;
+                    };
                 }
             }
             query
@@ -136,11 +161,11 @@ impl Queryable for Slice {
     ) -> Vec<LocatedNode<'b>> {
         if let Some(list) = current.as_array() {
             let mut result = Vec::new();
-            let step = self.step.unwrap_or(1);
+            let step = self.step.unwrap_or(Integer::from_i64_opt(1).unwrap());
             if step == 0 {
                 return vec![];
             }
-            let Ok(len) = isize::try_from(list.len()) else {
+            let Ok(len) = Integer::try_from(list.len()) else {
                 return vec![];
             };
             if step > 0 {
@@ -156,7 +181,11 @@ impl Queryable for Slice {
                             node,
                         });
                     }
-                    i += step;
+                    i = if let Some(i) = i.checked_add(step) {
+                        i
+                    } else {
+                        break;
+                    };
                 }
             } else {
                 let Some((lower, upper)) = self.bounds_on_reverse_slice(len) else {
@@ -173,7 +202,11 @@ impl Queryable for Slice {
                             node,
                         });
                     }
-                    i += step;
+                    i = if let Some(i) = i.checked_add(step) {
+                        i
+                    } else {
+                        break;
+                    };
                 }
             }
             result
@@ -183,10 +216,13 @@ impl Queryable for Slice {
     }
 }
 
-fn normalize_slice_index(index: isize, len: isize) -> Option<isize> {
+fn normalize_slice_index(index: Integer, len: Integer) -> Option<Integer> {
     if index >= 0 {
         Some(index)
     } else {
-        index.checked_abs().and_then(|i| len.checked_sub(i))
+        index
+            .checked_abs()
+            .and_then(|i| len.checked_sub(i))
+            .and_then(|i| Integer::try_from(i).ok())
     }
 }

--- a/serde_json_path_core/src/spec/selector/slice.rs
+++ b/serde_json_path_core/src/spec/selector/slice.rs
@@ -49,16 +49,31 @@ impl Slice {
         Self::default()
     }
 
+    /// Set the slice `start`
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the provided value is outside the range [-(2<sup>53</sup>) + 1, (2<sup>53</sup>) - 1].
     pub fn with_start(mut self, start: i64) -> Self {
         self.start = Some(Integer::from_i64_opt(start).expect("valid start"));
         self
     }
 
+    /// Set the slice `end`
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the provided value is outside the range [-(2<sup>53</sup>) + 1, (2<sup>53</sup>) - 1].
     pub fn with_end(mut self, end: i64) -> Self {
         self.end = Some(Integer::from_i64_opt(end).expect("valid end"));
         self
     }
 
+    /// Set the slice `step`
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the provided value is outside the range [-(2<sup>53</sup>) + 1, (2<sup>53</sup>) - 1].
     pub fn with_step(mut self, step: i64) -> Self {
         self.step = Some(Integer::from_i64_opt(step).expect("valid step"));
         self

--- a/serde_json_path_core/src/spec/selector/slice.rs
+++ b/serde_json_path_core/src/spec/selector/slice.rs
@@ -220,9 +220,6 @@ fn normalize_slice_index(index: Integer, len: Integer) -> Option<Integer> {
     if index >= 0 {
         Some(index)
     } else {
-        index
-            .checked_abs()
-            .and_then(|i| len.checked_sub(i))
-            .and_then(|i| Integer::try_from(i).ok())
+        index.checked_abs().and_then(|i| len.checked_sub(i))
     }
 }


### PR DESCRIPTION
This PR is to address [the recent CTS failure](https://github.com/hiltontj/serde_json_path/actions/runs/10232236116).

The JSONPath spec states that integers, e.g., those used as indices or in slice selectors, must be within a specific range [-2^53 +1, 2^53 - 1] (see [here](https://www.rfc-editor.org/rfc/rfc9535.html#section-2.1-4.1)).

The CTS recently added tests to verify this behaviour in https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/90, and `serde_json_path` which was not accounting for it, was failing the updated CTS.

This PR adds a new `Integer` type to represent such integers and check that they stay within that range. It also caught a couple of places where overflows would have led to panics.