### PR TITLE
chore: fix clippy lints from 1.83.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -94,7 +94,7 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/serde_json_path/src/path.rs
+++ b/serde_json_path/src/path.rs
@@ -133,7 +133,7 @@ impl<'de> Deserialize<'de> for JsonPath {
     {
         struct JsonPathVisitor;
 
-        impl<'de> Visitor<'de> for JsonPathVisitor {
+        impl Visitor<'_> for JsonPathVisitor {
             type Value = JsonPath;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/serde_json_path_core/src/node.rs
+++ b/serde_json_path_core/src/node.rs
@@ -552,19 +552,19 @@ impl<'a> Iterator for Locations<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Locations<'a> {
+impl DoubleEndedIterator for Locations<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(|l| l.location())
     }
 }
 
-impl<'a> ExactSizeIterator for Locations<'a> {
+impl ExactSizeIterator for Locations<'_> {
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 
-impl<'a> FusedIterator for Locations<'a> {}
+impl FusedIterator for Locations<'_> {}
 
 /// An iterator over the nodes in a [`LocatedNodeList`]
 ///
@@ -582,19 +582,19 @@ impl<'a> Iterator for Nodes<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Nodes<'a> {
+impl DoubleEndedIterator for Nodes<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(|l| l.node())
     }
 }
 
-impl<'a> ExactSizeIterator for Nodes<'a> {
+impl ExactSizeIterator for Nodes<'_> {
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
 
-impl<'a> FusedIterator for Nodes<'a> {}
+impl FusedIterator for Nodes<'_> {}
 
 /// Error produced when expecting no more than one node from a query
 #[derive(Debug, thiserror::Error)]

--- a/serde_json_path_core/src/path.rs
+++ b/serde_json_path_core/src/path.rs
@@ -170,7 +170,7 @@ impl<'a> IntoIterator for NormalizedPath<'a> {
     }
 }
 
-impl<'a> Display for NormalizedPath<'a> {
+impl Display for NormalizedPath<'_> {
     /// Format the [`NormalizedPath`] as a JSONPath string using the canonical bracket notation
     /// as per the [JSONPath Specification][norm-paths]
     ///
@@ -200,7 +200,7 @@ impl<'a> Display for NormalizedPath<'a> {
     }
 }
 
-impl<'a> Serialize for NormalizedPath<'a> {
+impl Serialize for NormalizedPath<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -218,7 +218,7 @@ pub enum PathElement<'a> {
     Index(usize),
 }
 
-impl<'a> PathElement<'a> {
+impl PathElement<'_> {
     fn to_json_pointer(&self) -> String {
         match self {
             PathElement::Name(s) => s.replace('~', "~0").replace('/', "~1"),
@@ -253,7 +253,7 @@ impl<'a> PathElement<'a> {
     }
 }
 
-impl<'a> PartialOrd for PathElement<'a> {
+impl PartialOrd for PathElement<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
             (PathElement::Name(a), PathElement::Name(b)) => a.partial_cmp(b),
@@ -263,7 +263,7 @@ impl<'a> PartialOrd for PathElement<'a> {
     }
 }
 
-impl<'a> PartialEq<str> for PathElement<'a> {
+impl PartialEq<str> for PathElement<'_> {
     fn eq(&self, other: &str) -> bool {
         match self {
             PathElement::Name(s) => s.eq(&other),
@@ -272,7 +272,7 @@ impl<'a> PartialEq<str> for PathElement<'a> {
     }
 }
 
-impl<'a> PartialEq<&str> for PathElement<'a> {
+impl PartialEq<&str> for PathElement<'_> {
     fn eq(&self, other: &&str) -> bool {
         match self {
             PathElement::Name(s) => s.eq(other),
@@ -281,7 +281,7 @@ impl<'a> PartialEq<&str> for PathElement<'a> {
     }
 }
 
-impl<'a> PartialEq<usize> for PathElement<'a> {
+impl PartialEq<usize> for PathElement<'_> {
     fn eq(&self, other: &usize) -> bool {
         match self {
             PathElement::Name(_) => false,
@@ -290,7 +290,7 @@ impl<'a> PartialEq<usize> for PathElement<'a> {
     }
 }
 
-impl<'a> Display for PathElement<'a> {
+impl Display for PathElement<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PathElement::Name(n) => write!(f, "{n}"),
@@ -305,13 +305,13 @@ impl<'a> From<&'a String> for PathElement<'a> {
     }
 }
 
-impl<'a> From<usize> for PathElement<'a> {
+impl From<usize> for PathElement<'_> {
     fn from(index: usize) -> Self {
         Self::Index(index)
     }
 }
 
-impl<'a> Serialize for PathElement<'a> {
+impl Serialize for PathElement<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/serde_json_path_core/src/spec/functions.rs
+++ b/serde_json_path_core/src/spec/functions.rs
@@ -228,7 +228,7 @@ impl<'a> Deref for NodesType<'a> {
     }
 }
 
-impl<'a> DerefMut for NodesType<'a> {
+impl DerefMut for NodesType<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -341,7 +341,7 @@ pub enum ValueType<'a> {
     Nothing,
 }
 
-impl<'a> ValueType<'a> {
+impl ValueType<'_> {
     #[doc(hidden)]
     pub const fn json_path_type() -> JsonPathType {
         JsonPathType::Value
@@ -387,7 +387,7 @@ impl<'a> TryFrom<JsonPathValue<'a>> for ValueType<'a> {
     }
 }
 
-impl<'a, T> From<T> for ValueType<'a>
+impl<T> From<T> for ValueType<'_>
 where
     T: Into<Value>,
 {
@@ -422,7 +422,7 @@ impl<'a> From<ValueType<'a>> for JsonPathValue<'a> {
     }
 }
 
-impl<'a> From<LogicalType> for JsonPathValue<'a> {
+impl From<LogicalType> for JsonPathValue<'_> {
     fn from(value: LogicalType) -> Self {
         Self::Logical(value)
     }
@@ -507,7 +507,7 @@ impl FunctionExpr<Validated> {
         &'a self,
         current: &'b Value,
         root: &'b Value,
-    ) -> JsonPathValue<'_> {
+    ) -> JsonPathValue<'a> {
         let args: VecDeque<JsonPathValue> = self
             .args
             .iter()


### PR DESCRIPTION
No issue for this. This fixes clippy lints from 1.83.0. Yay elided lifetimes.